### PR TITLE
Pull Request Target

### DIFF
--- a/.github/workflows/minimal-labels.yml
+++ b/.github/workflows/minimal-labels.yml
@@ -1,6 +1,6 @@
 name: Minimal Labels
 "on":
-    pull_request:
+    pull_request_target:
         types:
             - synchronize
             - reopened

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,6 @@
 name: Tests
 "on":
-    pull_request: {}
+    pull_request_target: {}
     push:
         branches:
             - main


### PR DESCRIPTION
Previously, the actions tied to pull requests executed on the pull_request event, which resulted in them not having access to the secrets required for them to execute.  At the beginning of August, GitHub added the pull_request_target event which operates in a similar way except only actions in the base commit would execute ensuring that it was safe to expose secrets. This change updates the pull request actions to use pull_request_target, ensuring that they are always functional.