### PR TITLE
Support No package.json

### DIFF
--- a/sherpa/nodejs.go
+++ b/sherpa/nodejs.go
@@ -23,11 +23,15 @@ import (
 	"path/filepath"
 )
 
-// NodeJSMainModule returns the name of the main module as defined in <path>/package.json.
+// NodeJSMainModule returns the name of the main module as defined in <path>/package.json. If no package.json exists,
+// or the package.json does not include a main entry, value defaults to server.js in line with the behavior of the
+// Paketo NodeJS buildpack.
 func NodeJSMainModule(path string) (string, error) {
 	file := filepath.Join(path, "package.json")
 	in, err := os.Open(file)
-	if err != nil {
+	if os.IsNotExist(err) {
+		return "server.js", nil
+	} else if err != nil {
 		return "", fmt.Errorf("unable to open %s\n%w", file, err)
 	}
 	defer in.Close()
@@ -39,7 +43,7 @@ func NodeJSMainModule(path string) (string, error) {
 
 	m, ok := raw["main"].(string)
 	if !ok {
-		return "", fmt.Errorf("no main module defined in %s: %+v", file, raw)
+		return "server.js", nil
 	}
 
 	return m, nil

--- a/sherpa/nodejs_test.go
+++ b/sherpa/nodejs_test.go
@@ -17,7 +17,6 @@
 package sherpa_test
 
 import (
-	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -47,19 +46,20 @@ func testNodeJS(t *testing.T, context spec.G, it spec.S) {
 		Expect(os.RemoveAll(path)).To(Succeed())
 	})
 
-	context("NodeJSMainModule", func() {
-		it("returns main module", func() {
-			Expect(ioutil.WriteFile(filepath.Join(path, "package.json"), []byte(`{ "main": "test-main" }`), 0644)).
-				To(Succeed())
+	it("returns server.js if no package.json exists", func() {
+		Expect(sherpa.NodeJSMainModule(path)).To(Equal("server.js"))
+	})
 
-			Expect(sherpa.NodeJSMainModule(path)).To(Equal("test-main"))
-		})
+	it("returns server.js if package.json does not have a main entry", func() {
+		Expect(ioutil.WriteFile(filepath.Join(path, "package.json"), []byte(`{}`), 0644)).To(Succeed())
 
-		it("returns error if no main module defined", func() {
-			Expect(ioutil.WriteFile(filepath.Join(path, "package.json"), []byte(`{}`), 0644)).To(Succeed())
+		Expect(sherpa.NodeJSMainModule(path)).To(Equal("server.js"))
+	})
 
-			_, err := sherpa.NodeJSMainModule(path)
-			Expect(err).To(MatchError(fmt.Errorf("no main module defined in %s: map[]", filepath.Join(path, "package.json"))))
-		})
+	it("returns main module", func() {
+		Expect(ioutil.WriteFile(filepath.Join(path, "package.json"), []byte(`{ "main": "test-main" }`), 0644)).
+			To(Succeed())
+
+		Expect(sherpa.NodeJSMainModule(path)).To(Equal("test-main"))
 	})
 }


### PR DESCRIPTION
Previously the `NodeJSMainModule` function would return an error if a NodeJS application did not have a `package.json` file.  This was incorrect as it is possible to have a legal NodeJS application without one and the Paketo NodeJS buildpack supports this style of application.

This change updates the detection logic to return `server.js` in cases where there is no `package.json` or the `package.json` does not explicitly identify a `main`, in line with the behavior of the Paketo NodeJS buildpack.
