### PR TITLE
Remove BurntSushi

### DIFF
--- a/carton/package.go
+++ b/carton/package.go
@@ -24,9 +24,9 @@ import (
 	"sort"
 	"text/template"
 
-	"github.com/BurntSushi/toml"
 	"github.com/buildpacks/libcnb"
 	"github.com/heroku/color"
+	"github.com/pelletier/go-toml"
 
 	"github.com/paketo-buildpacks/libpak"
 	"github.com/paketo-buildpacks/libpak/bard"
@@ -74,7 +74,12 @@ func (p Package) Create(options ...Option) {
 
 	buildpack := libcnb.Buildpack{}
 	file = filepath.Join(p.Source, "buildpack.toml")
-	if _, err = toml.DecodeFile(file, &buildpack); err != nil && !os.IsNotExist(err) {
+	b, err := ioutil.ReadFile(file)
+	if err != nil && !os.IsNotExist(err) {
+		config.exitHandler.Error(fmt.Errorf("unable to read %s\n%w", file, err))
+		return
+	}
+	if err := toml.Unmarshal(b, &buildpack); err != nil {
 		config.exitHandler.Error(fmt.Errorf("unable to decode buildpack %s\n%w", file, err))
 		return
 	}

--- a/dependency_cache.go
+++ b/dependency_cache.go
@@ -21,15 +21,16 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
 	"reflect"
 	"strings"
 
-	"github.com/BurntSushi/toml"
 	"github.com/buildpacks/libcnb"
 	"github.com/heroku/color"
+	"github.com/pelletier/go-toml"
 
 	"github.com/paketo-buildpacks/libpak/bard"
 )
@@ -129,7 +130,11 @@ func (d *DependencyCache) Artifact(dependency BuildpackDependency, mods ...Reque
 	}
 
 	file = filepath.Join(d.CachePath, fmt.Sprintf("%s.toml", dependency.SHA256))
-	if _, err := toml.DecodeFile(file, &actual); err != nil && !os.IsNotExist(err) {
+	b, err := ioutil.ReadFile(file)
+	if err != nil && !os.IsNotExist(err) {
+		return nil, fmt.Errorf("unable to read %s\n%w", file, err)
+	}
+	if err := toml.Unmarshal(b, &actual); err != nil {
 		return nil, fmt.Errorf("unable to decode download metadata %s\n%w", file, err)
 	}
 
@@ -139,7 +144,11 @@ func (d *DependencyCache) Artifact(dependency BuildpackDependency, mods ...Reque
 	}
 
 	file = filepath.Join(d.DownloadPath, fmt.Sprintf("%s.toml", dependency.SHA256))
-	if _, err := toml.DecodeFile(file, &actual); err != nil && !os.IsNotExist(err) {
+	b, err = ioutil.ReadFile(file)
+	if err != nil && !os.IsNotExist(err) {
+		return nil, fmt.Errorf("unable to read %s\n%w", file, err)
+	}
+	if err := toml.Unmarshal(b, &actual); err != nil {
 		return nil, fmt.Errorf("unable to decode download metadata %s\n%w", file, err)
 	}
 

--- a/dependency_cache_test.go
+++ b/dependency_cache_test.go
@@ -25,10 +25,10 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/BurntSushi/toml"
 	"github.com/buildpacks/libcnb"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/ghttp"
+	"github.com/pelletier/go-toml"
 	"github.com/sclevine/spec"
 
 	"github.com/paketo-buildpacks/libpak"

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/paketo-buildpacks/libpak
 go 1.15
 
 require (
-	github.com/BurntSushi/toml v0.3.1
 	github.com/Masterminds/semver/v3 v3.1.0
 	github.com/buildpacks/libcnb v1.18.0
 	github.com/creack/pty v1.1.11
@@ -11,6 +10,7 @@ require (
 	github.com/imdario/mergo v0.3.11
 	github.com/mattn/go-shellwords v1.0.10
 	github.com/onsi/gomega v1.10.3
+	github.com/pelletier/go-toml v1.8.1
 	github.com/sclevine/spec v1.4.0
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.6.1

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,9 @@ github.com/buildpacks/libcnb v1.18.0 h1:Q7I+HjQ1Cq02/AqhTOrzecuNESip9xE2axckxnym
 github.com/buildpacks/libcnb v1.18.0/go.mod h1:yzAQd//jyUXVx6Z/F0cKk/hrl49QZq1OE/hP5+/ZPuQ=
 github.com/creack/pty v1.1.11 h1:07n33Z8lZxZ2qwegKbObQohDhXDQxiMMz1NOUGYlesw=
 github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
@@ -39,10 +40,11 @@ github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+W
 github.com/onsi/ginkgo v1.12.1 h1:mFwc4LvZ0xpSvDZ3E+k8Yte0hLOMxXUlP+yXtJqkYfQ=
 github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108oapk=
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
-github.com/onsi/gomega v1.10.2 h1:aY/nuoWlKJud2J6U0E3NWsjlg+0GtwXxgEqthRdzlcs=
 github.com/onsi/gomega v1.10.2/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/onsi/gomega v1.10.3 h1:gph6h/qe9GSUw1NhH1gp+qb+h8rXD8Cy60Z32Qw3ELA=
 github.com/onsi/gomega v1.10.3/go.mod h1:V9xEwhxec5O8UDM77eCW8vLymOMltsqPVYWrpDsH8xc=
+github.com/pelletier/go-toml v1.8.1 h1:1Nf83orprkJyknT6h7zbuEGUEjcyVlCxSUGTENmNCRM=
+github.com/pelletier/go-toml v1.8.1/go.mod h1:T2/BmBdy8dvIRq1a/8aqjN41wvWlN4lrapLU/GW4pbc=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/sclevine/spec v1.4.0 h1:z/Q9idDcay5m5irkZ28M7PtQM4aOISzOpj4bUPkDee8=
@@ -59,7 +61,6 @@ golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACk
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
-golang.org/x/net v0.0.0-20200520004742-59133d7f0dd7 h1:AeiKBIuRw3UomYXSbLy0Mc2dDLfdtbT/IVn4keq83P0=
 golang.org/x/net v0.0.0-20200520004742-59133d7f0dd7/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20201006153459-a7d1128ccaa0 h1:wBouT66WTYFXdxfVdz9sVWARVd/2vfGcmI45D2gj45M=
 golang.org/x/net v0.0.0-20201006153459-a7d1128ccaa0/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
@@ -70,11 +71,9 @@ golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190904154756-749cb33beabd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191120155948-bd437916bb0e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd h1:xhmwyvizuTgC2qz7ZlMluP20uW+C3Rm0FD/WLDX8884=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f h1:+Nyd8tzPX9R7BWHguqsrbFdRx3WQ/1ib8I44HXV5yTA=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3 h1:cokOdA+Jmi5PJGXLlLllQSgYigAEfHXJAERHVMaCc2k=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=

--- a/internal/match_toml.go
+++ b/internal/match_toml.go
@@ -20,8 +20,8 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/BurntSushi/toml"
 	"github.com/onsi/gomega/types"
+	"github.com/pelletier/go-toml"
 )
 
 func MatchTOML(expected interface{}) types.GomegaMatcher {
@@ -35,35 +35,33 @@ type matchTOML struct {
 }
 
 func (matcher *matchTOML) Match(actual interface{}) (success bool, err error) {
-	var e, a string
+	var e, a []byte
 
 	switch eType := matcher.expected.(type) {
 	case string:
-		e = eType
+		e = []byte(eType)
 	case []byte:
-		e = string(eType)
+		e = eType
 	default:
 		return false, fmt.Errorf("expected value must be []byte or string, received %T", matcher.expected)
 	}
 
 	switch aType := actual.(type) {
 	case string:
-		a = aType
+		a = []byte(aType)
 	case []byte:
-		a = string(aType)
+		a = aType
 	default:
 		return false, fmt.Errorf("actual value must be []byte or string, received %T", matcher.expected)
 	}
 
 	var eValue map[string]interface{}
-	_, err = toml.Decode(e, &eValue)
-	if err != nil {
+	if err := toml.Unmarshal(e, &eValue); err != nil {
 		return false, err
 	}
 
 	var aValue map[string]interface{}
-	_, err = toml.Decode(a, &aValue)
-	if err != nil {
+	if err := toml.Unmarshal(a, &aValue); err != nil {
 		return false, err
 	}
 

--- a/internal/toml_writer.go
+++ b/internal/toml_writer.go
@@ -23,9 +23,9 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/BurntSushi/toml"
 	"github.com/buildpacks/libcnb"
 	"github.com/heroku/color"
+	"github.com/pelletier/go-toml"
 
 	"github.com/paketo-buildpacks/libpak/bard"
 )
@@ -118,7 +118,7 @@ func (t TOMLWriter) Write(path string, value interface{}) error {
 			t.logger.Header("Persistent metadata:")
 
 			var names []string
-			for k, _ := range v.Metadata {
+			for k := range v.Metadata {
 				names = append(names, k)
 			}
 


### PR DESCRIPTION
Previously, this project used the BurntSushi TOML library.  This library is now unmaintained and shouldn't be used for long term projects.  This change migrates the project onto an alternative TOML library.