### PR TITLE
Indented TOML

### DIFF
--- a/carton/buildpack_dependency.go
+++ b/carton/buildpack_dependency.go
@@ -27,7 +27,7 @@ import (
 )
 
 const (
-	BuildpackDependencyPattern      = `(?m)(.*id[\s]+=[\s]+"%s"\n.*\nversion[\s]+=[\s]+")%s("\nuri[\s]+=[\s]+").*("\nsha256[\s]+=[\s]+").*(".*)`
+	BuildpackDependencyPattern      = `(?m)([\s]*.*id[\s]+=[\s]+"%s"\n.*\n[\s]*version[\s]+=[\s]+")%s("\n[\s]*uri[\s]+=[\s]+").*("\n[\s]*sha256[\s]+=[\s]+").*(".*)`
 	BuildpackDependencySubstitution = "${1}%s${2}%s${3}%s${4}"
 )
 


### PR DESCRIPTION
Previously, when the buildpack-dependency application replaced the contents of a dependency, it expected the dependency declaration to be flushed left in the buildpack.toml file.  This isn't required by TOML and was too restrictive. This change loosens the regex to match against arbitrarily indented dependency declarations.

/cc @ameyer-pivotal @aemengo