### PR TITLE
Persist expected layer types even when layer is cached.

### DIFF
--- a/layer.go
+++ b/layer.go
@@ -61,7 +61,6 @@ func NewLayerContributor(name string, expectedMetadata interface{}, expectedType
 // LayerFunc is a callback function that is invoked when a layer needs to be contributed.
 type LayerFunc func() (libcnb.Layer, error)
 
-
 // Contribute is the function to call when implementing your libcnb.LayerContributor.
 func (l *LayerContributor) Contribute(layer libcnb.Layer, f LayerFunc) (libcnb.Layer, error) {
 	raw, err := toml.Marshal(l.ExpectedMetadata)
@@ -80,6 +79,7 @@ func (l *LayerContributor) Contribute(layer libcnb.Layer, f LayerFunc) (libcnb.L
 	// TODO: compare entire layer not just metadata (in case build, launch, or cache have changed)
 	if reflect.DeepEqual(expected, layer.Metadata) {
 		l.Logger.Headerf("%s: %s cached layer", color.BlueString(l.Name), color.GreenString("Reusing"))
+		layer.LayerTypes = l.ExpectedTypes
 		return layer, nil
 	}
 


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
This is required due to a change in the lifecycle API 0.6. See https://github.com/buildpacks/lifecycle/pull/537.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
