### PR TITLE
Adds convenience method to generate a file listing & return the hash of the listing

### DIFF
--- a/sherpa/file_listing.go
+++ b/sherpa/file_listing.go
@@ -46,6 +46,21 @@ type result struct {
 	value FileEntry
 }
 
+// NewFileListingHash generates a sha256 hash from the listing of all entries under the roots
+func NewFileListingHash(roots ...string) (string, error) {
+	files, err := NewFileListing(roots...)
+	if err != nil {
+		return "", fmt.Errorf("unable to create file listing\n%w", err)
+	}
+
+	hash := sha256.New()
+	for _, file := range files {
+		hash.Write([]byte(file.Path + file.Mode + file.SHA256 + "\n"))
+	}
+
+	return hex.EncodeToString(hash.Sum(nil)), nil
+}
+
 // NewFileListing generates a listing of all entries under the roots.
 func NewFileListing(roots ...string) ([]FileEntry, error) {
 	entries := make(chan FileEntry)


### PR DESCRIPTION
## Summary

The file listing mechanism is typically used to detect if changes have occurred under a directory. Rather than have the full details of the file listing, it's sufficient to compare hashes of the file listings. The hash also results in a smaller value, if you need to store that in metadata.

## Use Cases

Resolves #25 

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
