### PR TITLE
Implement `file://` downloads for artifacts

### DIFF
--- a/dependency_cache_test.go
+++ b/dependency_cache_test.go
@@ -223,7 +223,7 @@ func testDependencyCache(t *testing.T, context spec.G, it spec.S) {
 			Expect(ioutil.ReadAll(a)).To(Equal([]byte("test-fixture")))
 		})
 
-		context("uri is overridden", func() {
+		context("uri is overridden HTTP", func() {
 			it.Before(func() {
 				dependencyCache.Mappings = map[string]string{
 					dependency.SHA256: fmt.Sprintf("%s/override-path", server.URL()),
@@ -236,6 +236,26 @@ func testDependencyCache(t *testing.T, context spec.G, it spec.S) {
 					ghttp.RespondWith(http.StatusOK, "test-fixture"),
 				))
 
+				a, err := dependencyCache.Artifact(dependency)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(ioutil.ReadAll(a)).To(Equal([]byte("test-fixture")))
+			})
+		})
+
+		context("uri is overridden FILE", func() {
+			it.Before(func() {
+				sourcePath, err := ioutil.TempDir("", "dependency-source-path")
+				Expect(err).NotTo(HaveOccurred())
+				sourceFile := filepath.Join(sourcePath, "source-file")
+				Expect(ioutil.WriteFile(sourceFile, []byte("test-fixture"), 0644)).ToNot(HaveOccurred())
+
+				dependencyCache.Mappings = map[string]string{
+					dependency.SHA256: fmt.Sprintf("file://%s", sourceFile),
+				}
+			})
+
+			it("downloads from override filesystem", func() {
 				a, err := dependencyCache.Artifact(dependency)
 				Expect(err).NotTo(HaveOccurred())
 


### PR DESCRIPTION

## Summary

Allows URLs referenced by download artifacts to have the scheme of http, https, or file. Typically you would use http/https, but using file can be helpful when volume mounting pre-cached assets into the image.

## Use Cases

This can be used with dependency mapping bindings to volume mount in external pre-cached artifacts.

Resolves #36 

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
