### PR TITLE
Fixes a bug where file listing would fail if there is a relative symlink

### DIFF
--- a/sherpa/file_listing.go
+++ b/sherpa/file_listing.go
@@ -162,12 +162,15 @@ func process(entry FileEntry) (FileEntry, error) {
 	return entry, nil
 }
 
-func isSymlinkToDir(root string, f fs.FileInfo) (bool, error) {
+func isSymlinkToDir(symlink string, f fs.FileInfo) (bool, error) {
 	if f.Mode().Type() == fs.ModeSymlink {
-		// rawPath := filepath.Join(root, f.Name())
-		path, err := os.Readlink(root)
+		path, err := os.Readlink(symlink)
 		if err != nil {
-			return false, fmt.Errorf("unable to read symlink %s\n%w", root, err)
+			return false, fmt.Errorf("unable to read symlink %s\n%w", symlink, err)
+		}
+
+		if !filepath.IsAbs(path) {
+			path = filepath.Join(filepath.Dir(symlink), path)
 		}
 
 		stat, err := os.Stat(path)

--- a/sherpa/file_listing_test.go
+++ b/sherpa/file_listing_test.go
@@ -65,17 +65,19 @@ func testFileListing(t *testing.T, context spec.G, it spec.S) {
 		Expect(ioutil.WriteFile(filepath.Join(path, "test-directory", "bravo.txt"), []byte{2}, 0644)).To(Succeed())
 		Expect(os.Symlink(filepath.Join(path, "test-directory"), filepath.Join(path, "symlink-test-dir")))
 		Expect(os.Symlink(filepath.Join(path, "test-directory", "bravo.txt"), filepath.Join(path, "symlink-bravo.txt")))
+		Expect(os.Symlink("alpha.txt", filepath.Join(path, "symlink-relative.txt")))
 
 		e, err := sherpa.NewFileListing(path)
 		Expect(err).NotTo(HaveOccurred())
 
-		Expect(e).To(HaveLen(5))
+		Expect(e).To(HaveLen(6))
 		Expect(e[0].Path).To(HaveSuffix("alpha.txt"))
 		Expect(e[1].Path).To(HaveSuffix("symlink-bravo.txt"))
-		Expect(e[2].Path).To(HaveSuffix("symlink-test-dir"))
-		Expect(e[3].Path).To(HaveSuffix("test-directory"))
-		Expect(e[4].Path).To(HaveSuffix("bravo.txt"))
-		Expect(e[1].SHA256).To(Equal(e[4].SHA256)) // symlink to file should have hash of target file
+		Expect(e[2].Path).To(HaveSuffix("symlink-relative.txt"))
+		Expect(e[3].Path).To(HaveSuffix("symlink-test-dir"))
+		Expect(e[4].Path).To(HaveSuffix("test-directory"))
+		Expect(e[5].Path).To(HaveSuffix("bravo.txt"))
+		Expect(e[1].SHA256).To(Equal(e[5].SHA256)) // symlink to file should have hash of target file
 	})
 
 	it("create listing and get SHA256", func() {


### PR DESCRIPTION
## Summary

This will now resolve relative symlinks based on the parent directory of the symlink.

Ex: /foo/bar/my-link -> my-file
Then: it resolves my-link to /foo/bar/my-file


## Use Cases
Bug fix.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
