### PR TITLE
Switch from using io/fs to just using os which preserves Go 1.15 compatibility

### DIFF
--- a/sherpa/file_listing.go
+++ b/sherpa/file_listing.go
@@ -21,7 +21,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
-	"io/fs"
 	"os"
 	"path/filepath"
 	"sort"
@@ -162,8 +161,8 @@ func process(entry FileEntry) (FileEntry, error) {
 	return entry, nil
 }
 
-func isSymlinkToDir(symlink string, f fs.FileInfo) (bool, error) {
-	if f.Mode().Type() == fs.ModeSymlink {
+func isSymlinkToDir(symlink string, f os.FileInfo) (bool, error) {
+	if f.Mode().Type() == os.ModeSymlink {
 		path, err := os.Readlink(symlink)
 		if err != nil {
 			return false, fmt.Errorf("unable to read symlink %s\n%w", symlink, err)


### PR DESCRIPTION
## Summary

Change to remain compatible with Go 1.15 libraries.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
