### PR TITLE
Add Logging of Bindings Information for better UX

### DIFF
--- a/bindings/resolve.go
+++ b/bindings/resolve.go
@@ -18,7 +18,12 @@ package bindings
 
 import (
 	"fmt"
+	"os"
+	"sort"
 	"strings"
+
+	"github.com/heroku/color"
+	"github.com/paketo-buildpacks/libpak/bard"
 
 	"github.com/buildpacks/libcnb"
 )
@@ -45,15 +50,44 @@ func OfProvider(p string) Predicate {
 // Resolve returns all bindings from binds that match every Predicate in predicates.
 func Resolve(binds libcnb.Bindings, predicates ...Predicate) libcnb.Bindings {
 	var result libcnb.Bindings
+	logger := bard.NewLogger(os.Stdout)
+
 	// deep copy
 	for _, bind := range binds {
 		result = append(result, bind)
 	}
+
 	// filter on predicates
 	for _, p := range predicates {
 		result = filter(result, p)
 	}
+
+	LogBindings(result, logger)
 	return result
+}
+
+func LogBindings(bindings libcnb.Bindings, logger bard.Logger) {
+	f := color.New(color.Bold)
+
+	if len(bindings) > 0 {
+		logger.Header(f.Sprint("Bindings Identified:"))
+	} else {
+		logger.Header(f.Sprint("No Bindings Found"))
+	}
+
+	var s []string
+	for _, binding := range bindings {
+
+		for k := range binding.Secret {
+			s = append(s, k)
+		}
+		sort.Strings(s)
+
+		logger.Bodyf("Name: %s", binding.Name)
+		logger.Bodyf("Keys: %s", s)
+		s = nil
+	}
+
 }
 
 // ResolveOne returns a single binding from bindings that match every Predicate if present. If exactly one match is found

--- a/bindings/resolve_test.go
+++ b/bindings/resolve_test.go
@@ -17,7 +17,10 @@
 package bindings_test
 
 import (
+	"bytes"
 	"testing"
+
+	"github.com/paketo-buildpacks/libpak/bard"
 
 	"github.com/buildpacks/libcnb"
 	. "github.com/onsi/gomega"
@@ -29,8 +32,9 @@ import (
 func testResolve(t *testing.T, context spec.G, it spec.S) {
 	var (
 		Expect = NewWithT(t).Expect
-
-		binds libcnb.Bindings
+		b      *bytes.Buffer
+		logger bard.Logger
+		binds  libcnb.Bindings
 	)
 
 	it.Before(func() {
@@ -161,6 +165,44 @@ func testResolve(t *testing.T, context spec.G, it spec.S) {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(ok).To(BeFalse())
 			})
+		})
+	})
+
+	context("bindings are logged", func() {
+
+		it.Before(func() {
+			b = bytes.NewBuffer(nil)
+			logger = bard.NewLogger(b)
+			binds = []libcnb.Binding{
+				{
+					Name:     "name1",
+					Type:     "some-type",
+					Provider: "some-provider",
+					Secret:   map[string]string{"my-key1": "my-sec1"},
+				},
+				{
+					Name:     "name2",
+					Type:     "some-type",
+					Provider: "some-provider",
+					Secret:   map[string]string{"my-key2": "my-sec2"},
+				},
+			}
+		})
+
+		it("checks that binding info is logged", func() {
+
+			bindings.LogBindings(binds, logger)
+			Expect(b.String()).To(ContainSubstring("name1"))
+			Expect(b.String()).To(ContainSubstring("my-key1"))
+
+			Expect(b.String()).To(ContainSubstring("name2"))
+			Expect(b.String()).To(ContainSubstring("my-key2"))
+		})
+
+		it("checks that nothing is logged is no bindings found", func() {
+			binds = []libcnb.Binding{}
+			bindings.LogBindings(binds, logger)
+			Expect(b.String()).To(ContainSubstring("No Bindings Found"))
 		})
 	})
 }


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
Setting up bindings can be tricky - this adds logging when bindings are resolved, showing the binding name and keys so that users can see if they have been identified as expected during detection.

## Use Cases
Users attempting to leverage bindings at build/run time

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
