### PR TITLE
Support wildcard stacks in DependencyResolver

### DIFF
--- a/buildpack.go
+++ b/buildpack.go
@@ -424,8 +424,12 @@ func (d *DependencyResolver) Resolve(id string, version string) (BuildpackDepend
 }
 
 func (DependencyResolver) contains(candidates []string, value string) bool {
+	if len(candidates) == 0 {
+		return true
+	}
+
 	for _, c := range candidates {
-		if c == value {
+		if c == value || c == "*" {
 			return true
 		}
 	}

--- a/buildpack_test.go
+++ b/buildpack_test.go
@@ -261,6 +261,68 @@ func testBuildpack(t *testing.T, context spec.G, it spec.S) {
 				}))
 			})
 
+			it("filters by stack and supports the wildcard stack", func() {
+				resolver.Dependencies = []libpak.BuildpackDependency{
+					{
+						ID:      "test-id",
+						Name:    "test-name",
+						Version: "1.0",
+						URI:     "test-uri",
+						SHA256:  "test-sha256",
+						Stacks:  []string{"test-stack-1", "test-stack-2"},
+					},
+					{
+						ID:      "test-id",
+						Name:    "test-name",
+						Version: "1.0",
+						URI:     "test-uri",
+						SHA256:  "test-sha256",
+						Stacks:  []string{"*"},
+					},
+				}
+				resolver.StackID = "test-stack-3"
+
+				Expect(resolver.Resolve("test-id", "1.0")).To(Equal(libpak.BuildpackDependency{
+					ID:      "test-id",
+					Name:    "test-name",
+					Version: "1.0",
+					URI:     "test-uri",
+					SHA256:  "test-sha256",
+					Stacks:  []string{"*"},
+				}))
+			})
+
+			it("filters by stack and treats no stacks as the wildcard stack", func() {
+				resolver.Dependencies = []libpak.BuildpackDependency{
+					{
+						ID:      "test-id",
+						Name:    "test-name",
+						Version: "1.0",
+						URI:     "test-uri",
+						SHA256:  "test-sha256",
+						Stacks:  []string{"test-stack-1", "test-stack-2"},
+					},
+					{
+						ID:      "test-id",
+						Name:    "test-name",
+						Version: "1.0",
+						URI:     "test-uri",
+						SHA256:  "test-sha256",
+						Stacks:  []string{},
+					},
+				}
+				resolver.StackID = "test-stack-3"
+
+				Expect(resolver.Resolve("test-id", "1.0")).To(Equal(libpak.BuildpackDependency{
+					ID:      "test-id",
+					Name:    "test-name",
+					Version: "1.0",
+					URI:     "test-uri",
+					SHA256:  "test-sha256",
+					Stacks:  []string{},
+				}))
+			})
+
 			it("returns the best dependency", func() {
 				resolver.Dependencies = []libpak.BuildpackDependency{
 					{


### PR DESCRIPTION
## Summary

DependencyResolver.Resolve will filter based on stack name. This was an exact match only.

This patch enabled DependencyResolver to match if a buildpack author has either set the wildcard stack (i.e. `*`) for a dependency or if a buildpack author has set no stack information (also treated as wildcard).

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
