### PR TITLE
Skip `.git` folders in file listings

### DIFF
--- a/sherpa/file_listing.go
+++ b/sherpa/file_listing.go
@@ -84,6 +84,10 @@ func NewFileListing(roots ...string) ([]FileEntry, error) {
 					return nil
 				}
 
+				if info.IsDir() && info.Name() == ".git" {
+					return filepath.SkipDir
+				}
+
 				e := FileEntry{
 					Path: path,
 					Mode: info.Mode().String(),

--- a/sherpa/file_listing_test.go
+++ b/sherpa/file_listing_test.go
@@ -59,6 +59,22 @@ func testFileListing(t *testing.T, context spec.G, it spec.S) {
 		Expect(e).To(HaveLen(3))
 	})
 
+	it("create listing skipping .git folder", func() {
+		Expect(os.MkdirAll(filepath.Join(path, ".git"), 0755)).To(Succeed())
+		Expect(ioutil.WriteFile(filepath.Join(path, ".git", "HEAD"), []byte{1}, 0644)).To(Succeed())
+		Expect(ioutil.WriteFile(filepath.Join(path, ".git", "config"), []byte{1}, 0644)).To(Succeed())
+		Expect(ioutil.WriteFile(filepath.Join(path, "alpha.txt"), []byte{1}, 0644)).To(Succeed())
+		Expect(os.MkdirAll(filepath.Join(path, "test-directory"), 0755)).To(Succeed())
+		Expect(ioutil.WriteFile(filepath.Join(path, "test-directory", "bravo.txt"), []byte{2}, 0644)).To(Succeed())
+		Expect(os.MkdirAll(filepath.Join(path, "test-directory", ".git"), 0755)).To(Succeed())
+		Expect(ioutil.WriteFile(filepath.Join(path, "test-directory", ".git", "config"), []byte{1}, 0644)).To(Succeed())
+
+		e, err := sherpa.NewFileListing(path)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(e).To(HaveLen(3))
+	})
+
 	it("create listing as hash with non-regular file", func() {
 		Expect(ioutil.WriteFile(filepath.Join(path, "alpha.txt"), []byte{1}, 0644)).To(Succeed())
 		Expect(os.MkdirAll(filepath.Join(path, "test-directory"), 0755)).To(Succeed())


### PR DESCRIPTION
## Summary

The file listing mechanism will traverse all directories given to it & return a listing of all files. The main purpose of this mechanism is to detect changes under a directory structure. This change will skip `.git` folders as the file listing is traversing subdirectories. This is because `.git` folders are well-know, can change independent of the application (like if you change git config) but shouldn't trigger rebuilds of the application. In additiona, the `.git` directory can for larger projects contain a large number of files, so skipping it can help with performance on large projects.

This change will skip all folders with the name `.git`, not just the top-level `.git` folder.

This resolves #55.

## Use Cases

Improve performance and accuracy of file change detection.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
