### PR TITLE
Do not assume buildpack id ends with `-buildpacks`

### DIFF
--- a/carton/package_dependency.go
+++ b/carton/package_dependency.go
@@ -28,7 +28,7 @@ import (
 )
 
 const (
-	PackageIdDependencyPattern    = `(?m)(.*id[\s]+=[\s]+".+-buildpacks/%s",[\s]+version=")[^"]+(".*)`
+	PackageIdDependencyPattern    = `(?m)(.*id[\s]+=[\s]+".+/%s",[\s]+version=")[^"]+(".*)`
 	PackageImageDependencyPattern = `(?m)(.*uri[\s]+=[\s]+".*%s:)[^"]+(".*)`
 	PackageDependencySubstitution = "${1}%s${2}"
 )

--- a/carton/package_dependency_test.go
+++ b/carton/package_dependency_test.go
@@ -53,7 +53,7 @@ func testPackageDependency(t *testing.T, context spec.G, it spec.S) {
 		Expect(os.RemoveAll(path)).To(Succeed())
 	})
 
-	it("updates buildpack dependency", func() {
+	it("updates paketo-buildpacks dependency", func() {
 		Expect(ioutil.WriteFile(path, []byte(`
 { id = "paketo-buildpacks/test-1", version="test-version-1" },
 { id = "paketo-buildpacks/test-2", version="test-version-2" },
@@ -70,6 +70,26 @@ func testPackageDependency(t *testing.T, context spec.G, it spec.S) {
 		Expect(ioutil.ReadFile(path)).To(Equal([]byte(`
 { id = "paketo-buildpacks/test-1", version="test-version-3" },
 { id = "paketo-buildpacks/test-2", version="test-version-2" },
+`)))
+	})
+
+	it("updates paketocommunity dependency", func() {
+		Expect(ioutil.WriteFile(path, []byte(`
+{ id = "paketocommunity/test-1", version="test-version-1" },
+{ id = "paketocommunity/test-2", version="test-version-2" },
+`), 0644)).To(Succeed())
+
+		p := carton.PackageDependency{
+			BuildpackPath: path,
+			ID:            "docker.io/paketocommunity/test-1",
+			Version:       "test-version-3",
+		}
+
+		p.Update(carton.WithExitHandler(exitHandler))
+
+		Expect(ioutil.ReadFile(path)).To(Equal([]byte(`
+{ id = "paketocommunity/test-1", version="test-version-3" },
+{ id = "paketocommunity/test-2", version="test-version-2" },
 `)))
 	})
 
@@ -93,7 +113,7 @@ func testPackageDependency(t *testing.T, context spec.G, it spec.S) {
 `)))
 	})
 
-	it("updates package dependency", func() {
+	it("updates paketo-buildpacks package dependency", func() {
 		Expect(ioutil.WriteFile(path, []byte(`
 { uri = "docker://gcr.io/paketo-buildpacks/test-1:test-version-1" },
 { uri = "docker://gcr.io/paketo-buildpacks/test-2:test-version-2" },
@@ -110,6 +130,26 @@ func testPackageDependency(t *testing.T, context spec.G, it spec.S) {
 		Expect(ioutil.ReadFile(path)).To(Equal([]byte(`
 { uri = "docker://gcr.io/paketo-buildpacks/test-1:test-version-3" },
 { uri = "docker://gcr.io/paketo-buildpacks/test-2:test-version-2" },
+`)))
+	})
+
+	it("updates paketocommunity package dependency", func() {
+		Expect(ioutil.WriteFile(path, []byte(`
+{ uri = "docker://docker.io/paketocommunity/test-1:test-version-1" },
+{ uri = "docker://docker.io/paketocommunity/test-2:test-version-2" },
+`), 0644)).To(Succeed())
+
+		p := carton.PackageDependency{
+			PackagePath: path,
+			ID:          "docker.io/paketocommunity/test-1",
+			Version:     "test-version-3",
+		}
+
+		p.Update(carton.WithExitHandler(exitHandler))
+
+		Expect(ioutil.ReadFile(path)).To(Equal([]byte(`
+{ uri = "docker://docker.io/paketocommunity/test-1:test-version-3" },
+{ uri = "docker://docker.io/paketocommunity/test-2:test-version-2" },
 `)))
 	})
 


### PR DESCRIPTION
## Summary

The package id regular expression assumes that the package ID will be `<something>-buildpacks/<id>`. This works for `paketo-buildpacks/` and `tanzu-buildpacks/`. It does not work for the `paketocommunity`.

This commit modifes the regular expression to permit anything in the form `<something>/<id>`, which matches previous patterns plus `paketocommunity/` as well.

## Use Cases

This solves some issues with using libpak and carton tools in Paketo Community projects.

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
