### PR TITLE
Stop using regex to update dependencies in builder.toml, package.toml, and buildpack.toml

### DIFF
--- a/carton/buildpack_dependency.go
+++ b/carton/buildpack_dependency.go
@@ -72,8 +72,8 @@ func (b BuildpackDependency) Update(options ...Option) {
 	// save any leading comments, this is to preserve license headers
 	// inline comments will be lost
 	comments := []byte{}
-	for _, line := range bytes.SplitAfter(c, []byte("\n")) {
-		if bytes.HasPrefix(line, []byte("#")) || len(bytes.TrimSpace(line)) == 0 {
+	for i, line := range bytes.SplitAfter(c, []byte("\n")) {
+		if bytes.HasPrefix(line, []byte("#")) || (i > 0 && len(bytes.TrimSpace(line)) == 0) {
 			comments = append(comments, line...)
 		} else {
 			break // stop on first comment

--- a/carton/package.go
+++ b/carton/package.go
@@ -188,7 +188,7 @@ func (p Package) Create(options ...Option) {
 	}
 
 	var files []string
-	for d, _ := range entries {
+	for d := range entries {
 		files = append(files, d)
 	}
 	sort.Strings(files)

--- a/carton/package_dependency.go
+++ b/carton/package_dependency.go
@@ -148,8 +148,8 @@ func updateFile(cfgPath string, f func(md map[string]interface{})) error {
 	// save any leading comments, this is to preserve license headers
 	// inline comments will be lost
 	comments := []byte{}
-	for _, line := range bytes.SplitAfter(c, []byte("\n")) {
-		if bytes.HasPrefix(line, []byte("#")) || len(bytes.TrimSpace(line)) == 0 {
+	for i, line := range bytes.SplitAfter(c, []byte("\n")) {
+		if bytes.HasPrefix(line, []byte("#")) || (i > 0 && len(bytes.TrimSpace(line)) == 0) {
 			comments = append(comments, line...)
 		} else {
 			break // stop on first comment

--- a/carton/package_dependency.go
+++ b/carton/package_dependency.go
@@ -17,20 +17,15 @@
 package carton
 
 import (
+	"bytes"
 	"fmt"
 	"io/ioutil"
 	"os"
-	"regexp"
 	"strings"
 
 	"github.com/paketo-buildpacks/libpak/bard"
 	"github.com/paketo-buildpacks/libpak/internal"
-)
-
-const (
-	PackageIdDependencyPattern    = `(?m)(.*id[\s]+=[\s]+".+/%s",[\s]+version=")[^"]+(".*)`
-	PackageImageDependencyPattern = `(?m)(.*uri[\s]+=[\s]+".*%s:)[^"]+(".*)`
-	PackageDependencySubstitution = "${1}%s${2}"
+	"github.com/pelletier/go-toml"
 )
 
 type PackageDependency struct {
@@ -53,68 +48,131 @@ func (p PackageDependency) Update(options ...Option) {
 	logger := bard.NewLogger(os.Stdout)
 	_, _ = fmt.Fprintf(logger.TitleWriter(), "\n%s\n", bard.FormatIdentity(p.ID, p.Version))
 
-	var paths []string
 	if p.BuilderPath != "" {
-		paths = append(paths, p.BuilderPath)
+		if err := updateFile(p.BuilderPath, updateByKey("buildpacks", p.ID, p.Version)); err != nil {
+			config.exitHandler.Error(fmt.Errorf("unable to update %s\n%w", p.BuilderPath, err))
+		}
 	}
+
 	if p.PackagePath != "" {
-		paths = append(paths, p.PackagePath)
-	}
-
-	for _, path := range paths {
-		c, err := ioutil.ReadFile(path)
-		if err != nil {
-			config.exitHandler.Error(fmt.Errorf("unable to read %s\n%w", path, err))
-			return
-		}
-
-		s := fmt.Sprintf(PackageImageDependencyPattern, p.ID)
-		r, err := regexp.Compile(s)
-		if err != nil {
-			config.exitHandler.Error(fmt.Errorf("unable to compile regex %s\n%w", s, err))
-			return
-		}
-
-		if !r.Match(c) {
-			config.exitHandler.Error(fmt.Errorf("unable to match '%s'", s))
-			return
-		}
-
-		s = fmt.Sprintf(PackageDependencySubstitution, p.Version)
-		c = r.ReplaceAll(c, []byte(s))
-
-		if err := ioutil.WriteFile(path, c, 0644); err != nil {
-			config.exitHandler.Error(fmt.Errorf("unable to write %s\n%w", path, err))
-			return
+		if err := updateFile(p.PackagePath, updateByKey("dependencies", p.ID, p.Version)); err != nil {
+			config.exitHandler.Error(fmt.Errorf("unable to update %s\n%w", p.PackagePath, err))
 		}
 	}
 
 	if p.BuildpackPath != "" {
-		c, err := ioutil.ReadFile(p.BuildpackPath)
-		if err != nil {
-			config.exitHandler.Error(fmt.Errorf("unable to read %s\n%w", p.BuildpackPath, err))
-			return
-		}
+		if err := updateFile(p.BuildpackPath, func(md map[string]interface{}) {
+			parts := strings.Split(p.ID, "/")
+			id := strings.Join(parts[len(parts)-2:], "/")
 
-		id := strings.Join(strings.Split(p.ID, "/")[2:], "/")
-		s := fmt.Sprintf(PackageIdDependencyPattern, id)
-		r, err := regexp.Compile(s)
-		if err != nil {
-			config.exitHandler.Error(fmt.Errorf("unable to compile regex %s\n%w", s, err))
-			return
-		}
+			groupsUnwrapped, found := md["order"]
+			if !found {
+				return
+			}
 
-		if !r.Match(c) {
-			config.exitHandler.Error(fmt.Errorf("unable to match '%s'", s))
-			return
-		}
+			groups, ok := groupsUnwrapped.([]map[string]interface{})
+			if !ok {
+				return
+			}
 
-		s = fmt.Sprintf(PackageDependencySubstitution, p.Version)
-		c = r.ReplaceAll(c, []byte(s))
+			for _, group := range groups {
+				buildpacksUnwrapped, found := group["group"]
+				if !found {
+					continue
+				}
 
-		if err := ioutil.WriteFile(p.BuildpackPath, c, 0644); err != nil {
-			config.exitHandler.Error(fmt.Errorf("unable to write %s\n%w", p.BuildpackPath, err))
-			return
+				buildpacks, ok := buildpacksUnwrapped.([]map[string]interface{})
+				if !ok {
+					continue
+				}
+
+				for _, bp := range buildpacks {
+					bpIdUnwrappd, found := bp["id"]
+					if !found {
+						continue
+					}
+
+					bpId, ok := bpIdUnwrappd.(string)
+					if !ok {
+						continue
+					}
+
+					if bpId == id {
+						bp["version"] = p.Version
+					}
+				}
+			}
+		}); err != nil {
+			config.exitHandler.Error(fmt.Errorf("unable to update %s\n%w", p.BuildpackPath, err))
 		}
 	}
+}
+
+func updateByKey(key, id, version string) func(md map[string]interface{}) {
+	return func(md map[string]interface{}) {
+		valuesUnwrapped, found := md[key]
+		if !found {
+			return
+		}
+
+		values, ok := valuesUnwrapped.([]map[string]interface{})
+		if !ok {
+			return
+		}
+
+		for _, bp := range values {
+			uriUnwrapped, found := bp["uri"]
+			if !found {
+				continue
+			}
+
+			uri, ok := uriUnwrapped.(string)
+			if !ok {
+				continue
+			}
+
+			if strings.HasPrefix(uri, fmt.Sprintf("docker://%s", id)) {
+				parts := strings.Split(uri, ":")
+				bp["uri"] = fmt.Sprintf("%s:%s", strings.Join(parts[0:2], ":"), version)
+			}
+		}
+	}
+}
+
+func updateFile(cfgPath string, f func(md map[string]interface{})) error {
+	c, err := ioutil.ReadFile(cfgPath)
+	if err != nil {
+		return fmt.Errorf("unable to read %s\n%w", cfgPath, err)
+	}
+
+	// save any leading comments, this is to preserve license headers
+	// inline comments will be lost
+	comments := []byte{}
+	for _, line := range bytes.SplitAfter(c, []byte("\n")) {
+		if bytes.HasPrefix(line, []byte("#")) || len(bytes.TrimSpace(line)) == 0 {
+			comments = append(comments, line...)
+		} else {
+			break // stop on first comment
+		}
+	}
+
+	md := make(map[string]interface{})
+	if err := toml.Unmarshal(c, &md); err != nil {
+		return fmt.Errorf("unable to decode md %s\n%w", cfgPath, err)
+	}
+
+	f(md)
+
+	b, err := toml.Marshal(md)
+	if err != nil {
+		return fmt.Errorf("unable to encode md %s\n%w", cfgPath, err)
+	}
+
+	b = append(comments, b...)
+
+	if err := ioutil.WriteFile(cfgPath, b, 0644); err != nil {
+		return fmt.Errorf("unable to write %s\n%w", cfgPath, err)
+	}
+
+	return nil
 }

--- a/carton/package_dependency_test.go
+++ b/carton/package_dependency_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/stretchr/testify/mock"
 
 	"github.com/paketo-buildpacks/libpak/carton"
+	"github.com/paketo-buildpacks/libpak/internal"
 )
 
 func testPackageDependency(t *testing.T, context spec.G, it spec.S) {
@@ -53,11 +54,27 @@ func testPackageDependency(t *testing.T, context spec.G, it spec.S) {
 		Expect(os.RemoveAll(path)).To(Succeed())
 	})
 
-	it("updates paketo-buildpacks dependency", func() {
-		Expect(ioutil.WriteFile(path, []byte(`
-{ id = "paketo-buildpacks/test-1", version="test-version-1" },
-{ id = "paketo-buildpacks/test-2", version="test-version-2" },
-`), 0644)).To(Succeed())
+	it("updates paketo-buildpacks dependency without losing other fields", func() {
+		Expect(ioutil.WriteFile(path, []byte(`# it should preserve
+#   these comments
+#      exactly
+
+api = "0.6"
+[buildpack]
+id = "some-id"
+name = "some-name"
+
+[[order]]
+group = [
+	{ id = "paketo-buildpacks/test-1", version="test-version-1" },
+	{ id = "paketo-buildpacks/test-2", version="test-version-2" },
+]
+[metadata]
+include-files = [
+  "LICENSE",
+  "README.md",
+  "buildpack.toml",
+]`), 0644)).To(Succeed())
 
 		p := carton.PackageDependency{
 			BuildpackPath: path,
@@ -67,17 +84,59 @@ func testPackageDependency(t *testing.T, context spec.G, it spec.S) {
 
 		p.Update(carton.WithExitHandler(exitHandler))
 
-		Expect(ioutil.ReadFile(path)).To(Equal([]byte(`
-{ id = "paketo-buildpacks/test-1", version="test-version-3" },
-{ id = "paketo-buildpacks/test-2", version="test-version-2" },
-`)))
+		body, err := ioutil.ReadFile(path)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(body)).To(HavePrefix(`# it should preserve
+#   these comments
+#      exactly
+
+api = "0.6"`))
+		Expect(body).To(internal.MatchTOML(`api = "0.6"
+[buildpack]
+id = "some-id"
+name = "some-name"
+
+[[order]]
+group = [
+	{ id = "paketo-buildpacks/test-1", version="test-version-3" },
+	{ id = "paketo-buildpacks/test-2", version="test-version-2" },
+]
+[metadata]
+include-files = [
+  "LICENSE",
+  "README.md",
+  "buildpack.toml",
+]`))
+	})
+
+	it("updates paketo-buildpacks dependency id partial id", func() {
+		Expect(ioutil.WriteFile(path, []byte(`[[order]]
+group = [
+	{ id = "paketo-buildpacks/test-1", version="test-version-1" },
+	{ id = "paketo-buildpacks/test-2", version="test-version-2" },
+]`), 0644)).To(Succeed())
+
+		p := carton.PackageDependency{
+			BuildpackPath: path,
+			ID:            "paketo-buildpacks/test-1",
+			Version:       "test-version-3",
+		}
+
+		p.Update(carton.WithExitHandler(exitHandler))
+
+		Expect(ioutil.ReadFile(path)).To(internal.MatchTOML(`[[order]]
+group = [
+	{ id = "paketo-buildpacks/test-1", version="test-version-3" },
+	{ id = "paketo-buildpacks/test-2", version="test-version-2" },
+]`))
 	})
 
 	it("updates paketocommunity dependency", func() {
-		Expect(ioutil.WriteFile(path, []byte(`
-{ id = "paketocommunity/test-1", version="test-version-1" },
-{ id = "paketocommunity/test-2", version="test-version-2" },
-`), 0644)).To(Succeed())
+		Expect(ioutil.WriteFile(path, []byte(`[[order]]
+group = [
+	{ id = "paketocommunity/test-1", version="test-version-1" },
+	{ id = "paketocommunity/test-2", version="test-version-2" },
+]`), 0644)).To(Succeed())
 
 		p := carton.PackageDependency{
 			BuildpackPath: path,
@@ -87,17 +146,18 @@ func testPackageDependency(t *testing.T, context spec.G, it spec.S) {
 
 		p.Update(carton.WithExitHandler(exitHandler))
 
-		Expect(ioutil.ReadFile(path)).To(Equal([]byte(`
-{ id = "paketocommunity/test-1", version="test-version-3" },
-{ id = "paketocommunity/test-2", version="test-version-2" },
-`)))
+		Expect(ioutil.ReadFile(path)).To(internal.MatchTOML(`[[order]]
+group = [
+	{ id = "paketocommunity/test-1", version="test-version-3" },
+	{ id = "paketocommunity/test-2", version="test-version-2" },
+]`))
 	})
 
 	it("updates builder dependency", func() {
-		Expect(ioutil.WriteFile(path, []byte(`
-{ id = "paketo-buildpacks/test-1", uri = "docker://gcr.io/paketo-buildpacks/test-1:test-version-1" },
-{ id = "paketo-buildpacks/test-2", uri = "docker://gcr.io/paketo-buildpacks/test-2:test-version-2" },
-`), 0644)).To(Succeed())
+		Expect(ioutil.WriteFile(path, []byte(`buildpacks = [
+	{ id = "paketo-buildpacks/test-1", uri = "docker://gcr.io/paketo-buildpacks/test-1:test-version-1" },
+	{ id = "paketo-buildpacks/test-2", uri = "docker://gcr.io/paketo-buildpacks/test-2:test-version-2" },
+]`), 0644)).To(Succeed())
 
 		p := carton.PackageDependency{
 			BuilderPath: path,
@@ -107,17 +167,17 @@ func testPackageDependency(t *testing.T, context spec.G, it spec.S) {
 
 		p.Update(carton.WithExitHandler(exitHandler))
 
-		Expect(ioutil.ReadFile(path)).To(Equal([]byte(`
-{ id = "paketo-buildpacks/test-1", uri = "docker://gcr.io/paketo-buildpacks/test-1:test-version-3" },
-{ id = "paketo-buildpacks/test-2", uri = "docker://gcr.io/paketo-buildpacks/test-2:test-version-2" },
-`)))
+		Expect(ioutil.ReadFile(path)).To(internal.MatchTOML(`buildpacks = [
+	{ id = "paketo-buildpacks/test-1", uri = "docker://gcr.io/paketo-buildpacks/test-1:test-version-3" },
+	{ id = "paketo-buildpacks/test-2", uri = "docker://gcr.io/paketo-buildpacks/test-2:test-version-2" },
+]`))
 	})
 
 	it("updates paketo-buildpacks package dependency", func() {
-		Expect(ioutil.WriteFile(path, []byte(`
-{ uri = "docker://gcr.io/paketo-buildpacks/test-1:test-version-1" },
-{ uri = "docker://gcr.io/paketo-buildpacks/test-2:test-version-2" },
-`), 0644)).To(Succeed())
+		Expect(ioutil.WriteFile(path, []byte(`dependencies = [
+	{ uri = "docker://gcr.io/paketo-buildpacks/test-1:test-version-1" },
+	{ uri = "docker://gcr.io/paketo-buildpacks/test-2:test-version-2" },
+]`), 0644)).To(Succeed())
 
 		p := carton.PackageDependency{
 			PackagePath: path,
@@ -127,17 +187,17 @@ func testPackageDependency(t *testing.T, context spec.G, it spec.S) {
 
 		p.Update(carton.WithExitHandler(exitHandler))
 
-		Expect(ioutil.ReadFile(path)).To(Equal([]byte(`
-{ uri = "docker://gcr.io/paketo-buildpacks/test-1:test-version-3" },
-{ uri = "docker://gcr.io/paketo-buildpacks/test-2:test-version-2" },
-`)))
+		Expect(ioutil.ReadFile(path)).To(internal.MatchTOML(`dependencies = [
+	{ uri = "docker://gcr.io/paketo-buildpacks/test-1:test-version-3" },
+	{ uri = "docker://gcr.io/paketo-buildpacks/test-2:test-version-2" },
+]`))
 	})
 
 	it("updates paketocommunity package dependency", func() {
-		Expect(ioutil.WriteFile(path, []byte(`
-{ uri = "docker://docker.io/paketocommunity/test-1:test-version-1" },
-{ uri = "docker://docker.io/paketocommunity/test-2:test-version-2" },
-`), 0644)).To(Succeed())
+		Expect(ioutil.WriteFile(path, []byte(`dependencies = [
+	{ uri = "docker://docker.io/paketocommunity/test-1:test-version-1" },
+	{ uri = "docker://docker.io/paketocommunity/test-2:test-version-2" },
+]`), 0644)).To(Succeed())
 
 		p := carton.PackageDependency{
 			PackagePath: path,
@@ -147,10 +207,10 @@ func testPackageDependency(t *testing.T, context spec.G, it spec.S) {
 
 		p.Update(carton.WithExitHandler(exitHandler))
 
-		Expect(ioutil.ReadFile(path)).To(Equal([]byte(`
-{ uri = "docker://docker.io/paketocommunity/test-1:test-version-3" },
-{ uri = "docker://docker.io/paketocommunity/test-2:test-version-2" },
-`)))
+		Expect(ioutil.ReadFile(path)).To(internal.MatchTOML(`dependencies = [
+	{ uri = "docker://docker.io/paketocommunity/test-1:test-version-3" },
+	{ uri = "docker://docker.io/paketocommunity/test-2:test-version-2" },
+]`))
 	})
 
 }

--- a/carton/package_dependency_test.go
+++ b/carton/package_dependency_test.go
@@ -110,7 +110,8 @@ include-files = [
 	})
 
 	it("updates paketo-buildpacks dependency id partial id", func() {
-		Expect(ioutil.WriteFile(path, []byte(`[[order]]
+		Expect(ioutil.WriteFile(path, []byte(`
+[[order]]
 group = [
 	{ id = "paketo-buildpacks/test-1", version="test-version-1" },
 	{ id = "paketo-buildpacks/test-2", version="test-version-2" },


### PR DESCRIPTION
This includes:
- metadata dependencies
- composite buildpack.toml order groups
- package.toml files
- builder.toml files

Instead of using complicated, fragile regular expressions the code unmarshals the file from TOML to a map, traverses the map, locates the items to update, if found updates them, and then writes out the map as TOML. Using maps is a pain here, but it's done because unmarshaling to structs would require a lot of different, complicated structs that don't already exist. This would be a lot of effort because we only care about a very small subset of these files, creating structs to map out a bunch of stuff we don't care about.

Great care was put into ensuring that we are checking for keys to exist and for type assertions to be true. This should return sensible errors or skip bad data where possible.

The one downside of this approach that should be noted is that the TOML generated when we marshal the map back out to a file is controlled 100% by the TOML library. Thus the order for these files will likely change after the first time a dependency is updated. Fortunately, the order defined by the TOML library is static, so it won't change from update-to-update. There are just no options to control how it writes the TOML, so it's not possible to match our existing format.

On the plus side, this makes the update process way more robust because it also does not care about the incoming TOML format either. Any valid TOML format will work, which was not the case with the previous regular expression based update approach. That required a very specific TOML format.

Signed-off-by: Daniel Mikusa <dmikusa@vmware.com>

<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
