### PR TITLE
Adds sherpa.ResolveBool for use in helpers

### DIFF
--- a/sherpa/env_var.go
+++ b/sherpa/env_var.go
@@ -19,6 +19,7 @@ package sherpa
 import (
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 )
 
@@ -49,4 +50,20 @@ func GetEnvWithDefault(name string, def string) string {
 		return s
 	}
 	return def
+}
+
+// ResolveBool resolves a boolean value for a configuration option. Returns true for 1, t, T, TRUE, true, True. Returns
+// false for all other values or unset.
+func ResolveBool(name string) bool {
+	s, ok := os.LookupEnv(name)
+	if !ok {
+		return false
+	}
+
+	t, err := strconv.ParseBool(s)
+	if err != nil {
+		return false
+	}
+
+	return t
 }

--- a/sherpa/env_var_test.go
+++ b/sherpa/env_var_test.go
@@ -103,4 +103,53 @@ func testEnvVar(t *testing.T, context spec.G, it spec.S) {
 			Expect(sherpa.GetEnvWithDefault("ANOTHER_KEY", "default-value")).To(Equal("default-value"))
 		})
 	})
+
+	context("ResolveBool", func() {
+		context("variable not set", func() {
+			it("returns false if not set", func() {
+				Expect(sherpa.ResolveBool("TEST_KEY")).To(BeFalse())
+			})
+		})
+
+		context("variable is set to true value", func() {
+			it.After(func() {
+				Expect(os.Unsetenv("TEST_KEY")).To(Succeed())
+			})
+
+			it("returns true", func() {
+				for _, form := range []string{"1", "t", "T", "TRUE", "true", "True"} {
+					Expect(os.Setenv("TEST_KEY", form))
+					Expect(sherpa.ResolveBool("TEST_KEY")).To(BeTrue())
+					Expect(os.Unsetenv("TEST_KEY")).To(Succeed())
+				}
+			})
+		})
+
+		context("variable is set to non-true value", func() {
+			it.After(func() {
+				Expect(os.Unsetenv("TEST_KEY")).To(Succeed())
+			})
+
+			it("returns false", func() {
+				for _, form := range []string{"0", "f", "F", "FALSE", "false", "False"} {
+					Expect(os.Setenv("TEST_KEY", form))
+					Expect(sherpa.ResolveBool("TEST_KEY")).To(BeFalse())
+					Expect(os.Unsetenv("TEST_KEY")).To(Succeed())
+				}
+			})
+		})
+
+		context("variable is set to an invalid value", func() {
+			it.After(func() {
+				Expect(os.Unsetenv("TEST_KEY")).To(Succeed())
+			})
+
+			it("returns false", func() {
+				Expect(os.Setenv("TEST_KEY", "foo"))
+				Expect(sherpa.ResolveBool("TEST_KEY")).To(BeFalse())
+				Expect(os.Unsetenv("TEST_KEY")).To(Succeed())
+			})
+		})
+
+	})
 }


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
Provide the method with an env variable name and it will resolve & attempt to validate in a consistent way if the variable is true or false.

The function returns true for 1, t, T, TRUE, true, True. It returns false for all other values (even invalid) and if the variable is not set.

## Use Cases

For use in cases where ConfigurationResolver isn't appropriate, like in helpers.

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
