### PR TITLE
Fixes issues with incorrect indentation

### DIFF
--- a/bard/writer_test.go
+++ b/bard/writer_test.go
@@ -35,7 +35,7 @@ func testWriter(t *testing.T, context spec.G, it spec.S) {
 	context("Writer", func() {
 		var (
 			buffer *bytes.Buffer
-			writer bard.Writer
+			writer *bard.Writer
 		)
 
 		it.Before(func() {
@@ -95,6 +95,32 @@ func testWriter(t *testing.T, context spec.G, it spec.S) {
 					_, err := writer.Write([]byte("some-text\n"))
 					Expect(err).NotTo(HaveOccurred())
 					Expect(buffer.String()).To(Equal("\x1b[31m    some-text\x1b[0m\n"))
+				})
+			})
+
+			context("when there is multiple input", func() {
+				it.Before(func() {
+					writer = bard.NewWriter(buffer, bard.WithIndent(2))
+				})
+
+				it("skips indentation if there was not a line break", func() {
+					_, err := writer.Write([]byte("some-text"))
+					Expect(err).NotTo(HaveOccurred())
+
+					_, err = writer.Write([]byte("more-text"))
+					Expect(err).NotTo(HaveOccurred())
+
+					Expect(buffer.String()).To(Equal("    some-textmore-text"))
+				})
+
+				it("indents if there was a line break previously", func() {
+					_, err := writer.Write([]byte("some-text\na"))
+					Expect(err).NotTo(HaveOccurred())
+
+					_, err = writer.Write([]byte("more-text"))
+					Expect(err).NotTo(HaveOccurred())
+
+					Expect(buffer.String()).To(Equal("    some-text\n    amore-text"))
 				})
 			})
 


### PR DESCRIPTION
## Summary
Given a situation where bytes were written to the logger that do not end with a newline, then another set of bytes are written, the second set of bytes would be indented incorrectly. For example. First, write `some-data`, then write `more-data\nindent`. It should log `some-datamore-data\n    indent`, but it actually writes `some-data    more-data\n    indent`. There should not be an indent between the two writes because we only indent after a newline.


## Use Cases

This caused issues when indenting output from commands like `mvn` and `cargo`.

This PR resolves the issue and adds tests to confirm correct output.

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
