### PR TITLE
Adds support for DependencyLayerContributor and HelperLayerContributor to generate SBOMs

### DIFF
--- a/dependency_cache_test.go
+++ b/dependency_cache_test.go
@@ -153,6 +153,8 @@ func testDependencyCache(t *testing.T, context spec.G, it spec.S) {
 						URI:  "test-uri",
 					},
 				},
+				CPEs: []string{"cpe:2.3:a:some:jre:11.0.2:*:*:*:*:*:*:*"},
+				PURL: "pkg:generic/some-java11@11.0.2?arch=amd64",
 			}
 
 			dependencyCache = libpak.DependencyCache{

--- a/go.mod
+++ b/go.mod
@@ -5,10 +5,11 @@ go 1.15
 require (
 	github.com/CycloneDX/cyclonedx-go v0.4.0
 	github.com/Masterminds/semver/v3 v3.1.1
-	github.com/buildpacks/libcnb v1.24.1-0.20211118031525-6aa81e50810d
+	github.com/buildpacks/libcnb v1.25.0
 	github.com/creack/pty v1.1.17
 	github.com/heroku/color v0.0.6
 	github.com/imdario/mergo v0.3.12
+	github.com/mitchellh/hashstructure/v2 v2.0.2
 	github.com/onsi/gomega v1.17.0
 	github.com/pelletier/go-toml v1.9.4
 	github.com/sclevine/spec v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/Masterminds/semver/v3 v3.1.1 h1:hLg3sBzpNErnxhQtUy/mmLR2I9foDujNK030I
 github.com/Masterminds/semver/v3 v3.1.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
 github.com/bradleyjkemp/cupaloy/v2 v2.6.0 h1:knToPYa2xtfg42U3I6punFEjaGFKWQRXJwj0JTv4mTs=
 github.com/bradleyjkemp/cupaloy/v2 v2.6.0/go.mod h1:bm7JXdkRd4BHJk9HpwqAI8BoAY1lps46Enkdqw6aRX0=
-github.com/buildpacks/libcnb v1.24.1-0.20211118031525-6aa81e50810d h1:rAJsgF0p6rtUPGSTOCnCt/ofXKQM34wN+XKMXH3bNBE=
-github.com/buildpacks/libcnb v1.24.1-0.20211118031525-6aa81e50810d/go.mod h1:XX0+zHW8CNLNwiiwowgydAgWWfyDt8Lj1NcuWtkkBJQ=
+github.com/buildpacks/libcnb v1.25.0 h1:f0UWYUbXQ/vTX6SztGn+sP/F6cVSAbBQO4B5/R1LEP8=
+github.com/buildpacks/libcnb v1.25.0/go.mod h1:XX0+zHW8CNLNwiiwowgydAgWWfyDt8Lj1NcuWtkkBJQ=
 github.com/creack/pty v1.1.17 h1:QeVUsEDNrLBW4tMgZHvxy18sKtr6VI492kBhUfhDJNI=
 github.com/creack/pty v1.1.17/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -41,6 +41,8 @@ github.com/mattn/go-colorable v0.1.2 h1:/bC9yWikZXAL9uJdulbSfyVNIR3n3trXl+v8+1sx
 github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-isatty v0.0.8 h1:HLtExJ+uU2HOZ+wI0Tt5DtUDrx8yhUqDcp7fYERX4CE=
 github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
+github.com/mitchellh/hashstructure/v2 v2.0.2 h1:vGKWl0YJqUNxE8d+h8f6NJLcCJrgbhC4NcD46KavDd4=
+github.com/mitchellh/hashstructure/v2 v2.0.2/go.mod h1:MG3aRVU/N29oo/V/IhBX8GR/zz4kQkprJgF2EVszyDE=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=

--- a/sbom/init_test.go
+++ b/sbom/init_test.go
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package sherpa_test
+package sbom_test
 
 import (
 	"testing"
@@ -24,11 +24,7 @@ import (
 )
 
 func TestUnit(t *testing.T) {
-	suite := spec.New("libpak/sherpa", spec.Report(report.Terminal{}))
-	suite("CopyFile", testCopyFile)
-	suite("EnvVar", testEnvVar)
-	suite("FileListing", testFileListing)
-	suite("NodeJS", testNodeJS)
-	suite("Sherpa", testSherpa)
+	suite := spec.New("libpak/sbom", spec.Report(report.Terminal{}))
+	suite("SBOM", testSBOM)
 	suite.Run(t)
 }


### PR DESCRIPTION
- DependencyLayerContributor will write an SBOM with the dependency's metadata
- HelperLayerContributor will write an SBOM entry with the helper's metadata
- Both are written to the layer's SBOM file
- The DependencyLayerContributor support adds two new metadata fields to the BuildpackDependency object: `purl` and `cpes`.
  - purl is a string for the package URL, based on https://github.com/package-url/purl-spec
  - cpes is a list of strings for multiple CPE, or Common Platform Enumeration, identifiers
  - the values for these two fields are loaded from dependencies entries in buildpack.toml
  - if not specified, they default to the Go empty values
  - a single artifact entry is added for each dependency
- The HelpLayerContributor support generates a SBOM file with the following information. It is automatic and no additional metadata is required.
  - Name is `helper`
  - Version is the buildpack version
  - Licenses contains the buildpack's license
  - Locations contains a list of the helper names that are setup for this helper
  - CPEs is a list of `cpe:2.3:a:<buildpack-id>:<helper-name>:<buildpack-version:*:*:*:*:*:*:*`
  - PURL is `pkg:generic/<buildpack-id>@<buildpack-version>`
- ID hashes for all artifacts are calculated using `github.com/mitchellh/hashstructure/v2` and are a hash of the SyftArtifact object before setting the ID.

This functionality requires buildpack API 0.7, for older buildpack versions you may call these methods and they will function properly, however, the lifecycle will not persist any of the information generated.

Other incidental changes in this commit:

- Fixes a bug with `syft packages`. There was a typo in the command and th `-q` argument was missing.
- Moves SBOM functionality from the `sherpa` package into its own package `sbom`.
- Bumps to libcnb 1.25.0, which is required for the buildpack API 0.7 support.

Signed-off-by: Daniel Mikusa <dmikusa@vmware.com>
