### PR TITLE
Fix build flag for non windows files

### DIFF
--- a/effect/executor_unix.go
+++ b/effect/executor_unix.go
@@ -1,5 +1,5 @@
-//go:build aix && darwin && dragonfly && freebsd && linux && netbsd && openbsd && solaris
-// +build aix darwin dragonfly freebsd linux netbsd openbsd solaris
+//go:build !windows
+// +build !windows
 
 /*
  * Copyright 2018-2020 the original author or authors.


### PR DESCRIPTION
The previous flag was causing some issues and causing the NewExecutor function to vanish on mac and linux for go1.17.
Default to use `!windows` instead.

Might have been all the `&&`s?

Signed-off-by: Sambhav Kothari <skothari44@bloomberg.net>
