### PR TITLE
Add flags to update cpe & purl

### DIFF
--- a/carton/buildpack_dependency_test.go
+++ b/carton/buildpack_dependency_test.go
@@ -96,6 +96,56 @@ stacks  = [ "test-stack" ]
 `))
 	})
 
+	it("updates dependency with purl & cpes", func() {
+		Expect(ioutil.WriteFile(path, []byte(`api = "0.7"
+[buildpack]
+id = "some-buildpack"
+name = "Some Buildpack"
+version = "1.2.3"
+
+[[metadata.dependencies]]
+id      = "test-id"
+name    = "Test Name"
+version = "test-version-1"
+uri     = "test-uri-1"
+sha256  = "test-sha256-1"
+stacks  = [ "test-stack" ]
+purl    = "pkg:generic/test-jre@different-version-1?arch=amd64"
+cpes    = ["cpe:2.3:a:test-vendor:test-product:test-version-1:patch1:*:*:*:*:*:*:*"]
+`), 0644)).To(Succeed())
+
+		d := carton.BuildpackDependency{
+			BuildpackPath:  path,
+			ID:             "test-id",
+			SHA256:         "test-sha256-2",
+			URI:            "test-uri-2",
+			Version:        "test-version-2",
+			VersionPattern: `test-version-[\d]`,
+			PURL:           "different-version-2",
+			PURLPattern:    `different-version-[\d]`,
+			CPE:            "test-version-2:patch2",
+			CPEPattern:     `test-version-[\d]:patch[\d]`,
+		}
+
+		d.Update(carton.WithExitHandler(exitHandler))
+
+		Expect(ioutil.ReadFile(path)).To(internal.MatchTOML(`api = "0.7"
+[buildpack]
+id = "some-buildpack"
+name = "Some Buildpack"
+version = "1.2.3"
+
+[[metadata.dependencies]]id      = "test-id"
+name    = "Test Name"
+version = "test-version-2"
+uri     = "test-uri-2"
+sha256  = "test-sha256-2"
+stacks  = [ "test-stack" ]
+purl    = "pkg:generic/test-jre@different-version-2?arch=amd64"
+cpes    = ["cpe:2.3:a:test-vendor:test-product:test-version-2:patch2:*:*:*:*:*:*:*"]
+`))
+	})
+
 	it("updates indented dependency", func() {
 		Expect(ioutil.WriteFile(path, []byte(`# it should preserve
 #   these comments

--- a/cmd/update-buildpack-dependency/main.go
+++ b/cmd/update-buildpack-dependency/main.go
@@ -36,6 +36,10 @@ func main() {
 	flagSet.StringVar(&b.URI, "uri", "", "the new uri of the dependency")
 	flagSet.StringVar(&b.Version, "version", "", "the new version of the dependency")
 	flagSet.StringVar(&b.VersionPattern, "version-pattern", "", "the version pattern of the dependency")
+	flagSet.StringVar(&b.PURL, "purl", "", "the new purl version of the dependency, if not set defaults to version")
+	flagSet.StringVar(&b.PURLPattern, "purl-pattern", "", "the purl version pattern of the dependency, if not set defaults to version-pattern")
+	flagSet.StringVar(&b.CPE, "cpe", "", "the new version use in all CPEs, if not set defaults to version")
+	flagSet.StringVar(&b.CPEPattern, "cpe-pattern", "", "the cpe version pattern of the dependency, if not set defaults to version-pattern")
 
 	if err := flagSet.Parse(os.Args[1:]); err != nil {
 		log.Fatal(fmt.Errorf("unable to parse flags\n%w", err))
@@ -63,6 +67,22 @@ func main() {
 
 	if b.VersionPattern == "" {
 		log.Fatal("version-pattern must be set")
+	}
+
+	if b.PURL == "" {
+		b.PURL = b.Version
+	}
+
+	if b.PURLPattern == "" {
+		b.PURLPattern = b.VersionPattern
+	}
+
+	if b.CPE == "" {
+		b.CPE = b.Version
+	}
+
+	if b.CPEPattern == "" {
+		b.CPEPattern = b.VersionPattern
 	}
 
 	b.Update()


### PR DESCRIPTION
## Summary

- adds flags for updating cpes, `--cpe` and `--cpe-pattern`. The command will do a replace-all on each CPE with the given pattern, inserting the cpe value if found.
- adds flags for updating purl, `--purl` and `--purl-pattern`. The command will do a relpace-all on the PURL with the given pattern, inserting the purl value if found.
- if flags are not set, they will default to `--version` and `--version-pattern`. This is generally the behavior that is required, so most of the time the additonal flags won't be needed.
- adds test to validate that version, cpe and purl can be updated independently.

## Use Cases

With the introduction of CPEs and PURL to dependency metadata, we need a way to update this metadata since it almost always includes the version number in it.

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
