### PR TITLE
Fixes a bug where buildpack_dependency's `Update(..)` method will update the wrong dependencies

### DIFF
--- a/carton/buildpack_dependency.go
+++ b/carton/buildpack_dependency.go
@@ -152,36 +152,29 @@ func (b BuildpackDependency) Update(options ...Option) {
 				dep["version"] = b.Version
 				dep["uri"] = b.URI
 				dep["sha256"] = b.SHA256
-			}
 
-			purlUnwrapped, found := dep["purl"]
-			if !found {
-				continue
-			}
-
-			purl, ok := purlUnwrapped.(string)
-			if !ok {
-				continue
-			}
-			dep["purl"] = purlExp.ReplaceAllString(purl, b.PURL)
-
-			cpesUnwrapped, found := dep["cpes"]
-			if !found {
-				continue
-			}
-
-			cpes, ok := cpesUnwrapped.([]interface{})
-			if !ok {
-				continue
-			}
-
-			for i := 0; i < len(cpes); i++ {
-				cpe, ok := cpes[i].(string)
-				if !ok {
-					continue
+				purlUnwrapped, found := dep["purl"]
+				if found {
+					purl, ok := purlUnwrapped.(string)
+					if ok {
+						dep["purl"] = purlExp.ReplaceAllString(purl, b.PURL)
+					}
 				}
 
-				cpes[i] = cpeExp.ReplaceAllString(cpe, b.CPE)
+				cpesUnwrapped, found := dep["cpes"]
+				if found {
+					cpes, ok := cpesUnwrapped.([]interface{})
+					if ok {
+						for i := 0; i < len(cpes); i++ {
+							cpe, ok := cpes[i].(string)
+							if !ok {
+								continue
+							}
+
+							cpes[i] = cpeExp.ReplaceAllString(cpe, b.CPE)
+						}
+					}
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

Prior to this PR, the version number was not considered when updating the CPEs and PURL. If for example, you have two different major version branches that you are including in buildpack.toml, such as Java 11 and Java 17, prior to this PR trying to update the version of Java 11 could result in the CPE & PURL for both Java 11 and Java 17 being updated.

This PR adds tests to replicate the case where depenencies that don't match the version pattern are having their CPE/PURL updated incorrectly. It also addresses the issue by only modifying the CPE & PURL if the version pattern matches, which is the same criteria applied for updating the URL/SHA/VERSION.

## Use Cases

Fixes minor bug that causes some edge case problems.

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
