### PR TITLE
Removes logic to restrict output of deprecated label-based BOM entries

### DIFF
--- a/layer.go
+++ b/layer.go
@@ -140,18 +140,15 @@ func NewDependencyLayer(dependency BuildpackDependency, cache DependencyCache, t
 		ExpectedTypes:    types,
 	}
 
-	var entry libcnb.BOMEntry
-	if dependency.PURL == "" && len(dependency.CPEs) == 0 {
-		entry = dependency.AsBOMEntry()
-		entry.Metadata["layer"] = c.LayerName()
+	entry := dependency.AsBOMEntry()
+	entry.Metadata["layer"] = c.LayerName()
 
-		if types.Launch {
-			entry.Launch = true
-		}
-		if !(types.Launch && !types.Cache && !types.Build) {
-			// launch-only layers are the only layers NOT guaranteed to be present in the build environment
-			entry.Build = true
-		}
+	if types.Launch {
+		entry.Launch = true
+	}
+	if !(types.Launch && !types.Cache && !types.Build) {
+		// launch-only layers are the only layers NOT guaranteed to be present in the build environment
+		entry.Build = true
 	}
 
 	return c, entry
@@ -226,20 +223,15 @@ func NewHelperLayer(buildpack libcnb.Buildpack, names ...string) (HelperLayerCon
 		BuildpackInfo: buildpack.Info,
 	}
 
-	var entry libcnb.BOMEntry
-	if buildpack.API == "0.6" || buildpack.API == "0.5" || buildpack.API == "0.4" || buildpack.API == "0.3" || buildpack.API == "0.2" || buildpack.API == "0.1" {
-		entry = libcnb.BOMEntry{
-			Name: "helper",
-			Metadata: map[string]interface{}{
-				"layer":   c.Name(),
-				"names":   names,
-				"version": buildpack.Info.Version,
-			},
-			Launch: true,
-		}
+	return c, libcnb.BOMEntry{
+		Name: "helper",
+		Metadata: map[string]interface{}{
+			"layer":   c.Name(),
+			"names":   names,
+			"version": buildpack.Info.Version,
+		},
+		Launch: true,
 	}
-
-	return c, entry
 }
 
 // Name returns the conventional name of the layer for this contributor

--- a/layer_test.go
+++ b/layer_test.go
@@ -290,23 +290,6 @@ func testLayer(t *testing.T, context spec.G, it spec.S) {
 				Expect(entry.Build).To(BeTrue())
 			})
 		})
-
-		context("no BOM entry when PURL is set", func() {
-			it("sets build on the entry", func() {
-				dep.PURL = "pkg:generic/fake@1.0.0"
-				_, entry := libpak.NewDependencyLayer(dep, libpak.DependencyCache{}, libcnb.LayerTypes{})
-				Expect(entry).To(Equal(libcnb.BOMEntry{}))
-			})
-
-			it("sets build on the entry", func() {
-				dep.CPEs = []string{
-					"cpe:1",
-					"cpe:2",
-				}
-				_, entry := libpak.NewDependencyLayer(dep, libpak.DependencyCache{}, libcnb.LayerTypes{})
-				Expect(entry).To(Equal(libcnb.BOMEntry{}))
-			})
-		})
 	})
 
 	context("DependencyLayerContributor", func() {
@@ -553,14 +536,23 @@ func testLayer(t *testing.T, context spec.G, it spec.S) {
 			))
 		})
 
-		it("returns empty BOM entry on API 0.7", func() {
+		it("returns a BOM entry on API 0.7 too", func() {
 			_, entry := libpak.NewHelperLayer(libcnb.Buildpack{
 				API: "0.7",
 				Info: libcnb.BuildpackInfo{
 					Version: "test-version",
 				},
 			}, "test-name-1", "test-name-2")
-			Expect(entry).To(Equal(libcnb.BOMEntry{}))
+			Expect(entry).To(Equal(libcnb.BOMEntry{
+				Name: filepath.Base("helper"),
+				Metadata: map[string]interface{}{
+					"layer":   "helper",
+					"names":   []string{"test-name-1", "test-name-2"},
+					"version": "test-version",
+				},
+				Launch: true,
+				Build:  false,
+			}))
 		})
 	})
 


### PR DESCRIPTION
## Summary

Starting with lifecycle 0.13.3, it is permitted to have both the old style label-based BOM information and the new style layer-based BOM information. If the buildpack API is 0.6 or older, label-based BOMs only is OK. If the buildpack API is 0.7, you may have both label-based BOM and layer-based BOM or just layer-based BOM. It is permitted to have just label-based BOM, however, that will generate a warning from the lifecycle.

Given this, we're removing the logic which conditionally controlled the BOM formats that were output. Going forward DependencyLayerContributor and HelperLayerContributor will always output both BOM formats.

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
