### PR TITLE
Allow disabling the BOM label

### DIFF
--- a/main.go
+++ b/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/buildpacks/libcnb"
 
 	"github.com/paketo-buildpacks/libpak/internal"
+	"github.com/paketo-buildpacks/libpak/sherpa"
 )
 
 // Main is called by the main function of a buildpack, encapsulating both detection and build in the same binary.
@@ -29,6 +30,7 @@ func Main(detector libcnb.Detector, builder libcnb.Builder, options ...libcnb.Op
 			libcnb.WithEnvironmentWriter(internal.NewEnvironmentWriter()),
 			libcnb.WithExitHandler(internal.NewExitHandler()),
 			libcnb.WithTOMLWriter(internal.NewTOMLWriter()),
+			libcnb.WithBOMLabel(!sherpa.ResolveBool("BP_BOM_LABEL_DISABLED")),
 		}, options...)...,
 	)
 }


### PR DESCRIPTION
## Summary

We are currently supporting the old-style BOM label and the new-style SBOM layer. By default, we output both.

In some situations, if the BOM label grows large enough the resulting will not run on Kubernetes. It fails because the label is too large. You may now set the `BP_BOM_LABEL_DISABLED` env variable to `true` and on the next build, the BOM label will not be included with the image.

The label is included by default, despite this known issue, to for backward compatibility.

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
