### PR TITLE
Add a helper to extract an archive based on mime type

### DIFF
--- a/crush/crush_test.go
+++ b/crush/crush_test.go
@@ -223,5 +223,112 @@ func testCrush(t *testing.T, context spec.G, it spec.S) {
 				Expect(filepath.Join(path, "fileC.txt")).To(BeARegularFile())
 			})
 		})
+
+		context("ExtractArchive", func() {
+			context("Tar", func() {
+				it.Before(func() {
+					var err error
+					in, err = os.Open(filepath.Join("testdata", "test-archive.tar"))
+					Expect(err).NotTo(HaveOccurred())
+				})
+
+				it("extracts the archive", func() {
+					Expect(crush.ExtractArchive(in, path, 0)).To(Succeed())
+					Expect(filepath.Join(path, "fileA.txt")).To(BeARegularFile())
+					Expect(filepath.Join(path, "dirA", "fileB.txt")).To(BeARegularFile())
+					Expect(filepath.Join(path, "dirA", "fileC.txt")).To(BeARegularFile())
+				})
+
+				it("skips stripped components", func() {
+					Expect(crush.ExtractArchive(in, path, 1)).To(Succeed())
+					Expect(filepath.Join(path, "fileB.txt")).To(BeARegularFile())
+					Expect(filepath.Join(path, "fileC.txt")).To(BeARegularFile())
+				})
+			})
+
+			context("TarGZ", func() {
+				it.Before(func() {
+					var err error
+					in, err = os.Open(filepath.Join("testdata", "test-archive.tar.gz"))
+					Expect(err).NotTo(HaveOccurred())
+				})
+
+				it("extracts the archive", func() {
+					Expect(crush.ExtractArchive(in, path, 0)).To(Succeed())
+					Expect(filepath.Join(path, "fileA.txt")).To(BeARegularFile())
+					Expect(filepath.Join(path, "dirA", "fileB.txt")).To(BeARegularFile())
+					Expect(filepath.Join(path, "dirA", "fileC.txt")).To(BeARegularFile())
+				})
+
+				it("skips stripped components", func() {
+					Expect(crush.ExtractArchive(in, path, 1)).To(Succeed())
+					Expect(filepath.Join(path, "fileB.txt")).To(BeARegularFile())
+					Expect(filepath.Join(path, "fileC.txt")).To(BeARegularFile())
+				})
+			})
+
+			context("TarBz2", func() {
+				it.Before(func() {
+					var err error
+					in, err = os.Open(filepath.Join("testdata", "test-archive.tar.bz2"))
+					Expect(err).NotTo(HaveOccurred())
+				})
+
+				it("extracts the archive", func() {
+					Expect(crush.ExtractArchive(in, path, 0)).To(Succeed())
+					Expect(filepath.Join(path, "fileA.txt")).To(BeARegularFile())
+					Expect(filepath.Join(path, "dirA", "fileB.txt")).To(BeARegularFile())
+					Expect(filepath.Join(path, "dirA", "fileC.txt")).To(BeARegularFile())
+				})
+
+				it("skips stripped components", func() {
+					Expect(crush.ExtractArchive(in, path, 1)).To(Succeed())
+					Expect(filepath.Join(path, "fileB.txt")).To(BeARegularFile())
+					Expect(filepath.Join(path, "fileC.txt")).To(BeARegularFile())
+				})
+			})
+
+			context("TarXZ", func() {
+				it.Before(func() {
+					var err error
+					in, err = os.Open(filepath.Join("testdata", "test-archive.tar.xz"))
+					Expect(err).NotTo(HaveOccurred())
+				})
+
+				it("extracts the archive", func() {
+					Expect(crush.ExtractArchive(in, path, 0)).To(Succeed())
+					Expect(filepath.Join(path, "fileA.txt")).To(BeARegularFile())
+					Expect(filepath.Join(path, "dirA", "fileB.txt")).To(BeARegularFile())
+					Expect(filepath.Join(path, "dirA", "fileC.txt")).To(BeARegularFile())
+				})
+
+				it("skips stripped components", func() {
+					Expect(crush.ExtractArchive(in, path, 1)).To(Succeed())
+					Expect(filepath.Join(path, "fileB.txt")).To(BeARegularFile())
+					Expect(filepath.Join(path, "fileC.txt")).To(BeARegularFile())
+				})
+			})
+
+			context("Zip", func() {
+				it.Before(func() {
+					var err error
+					in, err = os.Open(filepath.Join("testdata", "test-archive.zip"))
+					Expect(err).NotTo(HaveOccurred())
+				})
+
+				it("extracts the archive", func() {
+					Expect(crush.ExtractArchive(in, path, 0)).To(Succeed())
+					Expect(filepath.Join(path, "fileA.txt")).To(BeARegularFile())
+					Expect(filepath.Join(path, "dirA", "fileB.txt")).To(BeARegularFile())
+					Expect(filepath.Join(path, "dirA", "fileC.txt")).To(BeARegularFile())
+				})
+
+				it("skips stripped components", func() {
+					Expect(crush.ExtractArchive(in, path, 1)).To(Succeed())
+					Expect(filepath.Join(path, "fileB.txt")).To(BeARegularFile())
+					Expect(filepath.Join(path, "fileC.txt")).To(BeARegularFile())
+				})
+			})
+		})
 	})
 }

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/Masterminds/semver/v3 v3.1.1
 	github.com/buildpacks/libcnb v1.25.5
 	github.com/creack/pty v1.1.17
+	github.com/h2non/filetype v1.1.3
 	github.com/heroku/color v0.0.6
 	github.com/imdario/mergo v0.3.12
 	github.com/mitchellh/hashstructure/v2 v2.0.2

--- a/go.sum
+++ b/go.sum
@@ -31,6 +31,8 @@ github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/pprof v0.0.0-20210407192527-94a9f03dee38/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
+github.com/h2non/filetype v1.1.3 h1:FKkx9QbD7HR/zjK1Ia5XiBsq9zdLi5Kf3zGyFTAFkGg=
+github.com/h2non/filetype v1.1.3/go.mod h1:319b3zT68BvV+WRj7cwy856M2ehB3HqNOt6sy1HndBY=
 github.com/heroku/color v0.0.6 h1:UTFFMrmMLFcL3OweqP1lAdp8i1y/9oHqkeHjQ/b/Ny0=
 github.com/heroku/color v0.0.6/go.mod h1:ZBvOcx7cTF2QKOv4LbmoBtNl5uB17qWxGuzZrsi1wLU=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=


### PR DESCRIPTION
## Summary
A helper function to extract an archive based on file type

## Use Cases
Determines the mime type of the file, and uses the correct method to extract the archive, this will help avoid lots of `if else if ...` logic in various method.

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
