### PR TITLE
Add Jammy Jellyfish stack IDs

### DIFF
--- a/stack.go
+++ b/stack.go
@@ -20,6 +20,17 @@ const (
 	// BionicStackID is the ID for the Cloud Native Buildpacks bionic stack.
 	BionicStackID = "io.buildpacks.stacks.bionic"
 
-	// TinyStackID is the ID for the Paketo Buildpacks tiny stack.
+	// BionicTinyStackID is the ID for the Paketo Buildpacks bionic tiny stack.
+	BionicTinyStackID = "io.paketo.stacks.tiny"
+
+	// TinyStackID is the ID for the Paketo Buildpacks bionic tiny stack.
+	//
+	// Deprecated: use BionicTinyStackID instead
 	TinyStackID = "io.paketo.stacks.tiny"
+
+	// JammyStackID is the ID for the Cloud Native Buildpacks jammy stack.
+	JammyStackID = "io.buildpacks.stacks.jammy"
+
+	// JammyTinyStackID is the ID for the Cloud Native Buildpacks jammy tiny stack.
+	JammyTinyStackID = "io.buildpacks.stacks.jammy.tiny"
 )


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
As part of [Paketo Stacks RFC 0004](https://github.com/paketo-buildpacks/rfcs/blob/da3339d071ffed23c3cd1b374a6bfcefdea7ac70/text/stacks/0004-jammy-jellyfish.md), Paketo is creating 3 new stacks based on the Ubuntu Jammy Jellyfish linux distribution. The stack IDs for these stacks are enumerated in the RFC. This PR adds the stack IDs as constants.

It also deprecates `TinyStackID` since its meaning is now ambiguous.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
