### PR TITLE
Returns an error if exec.Command would resolve relative to current dir

### DIFF
--- a/effect/executor.go
+++ b/effect/executor.go
@@ -19,6 +19,8 @@ package effect
 import (
 	"io"
 	"os/exec"
+	"fmt"
+	"errors"
 )
 
 // Execution is information about a command to run.
@@ -73,5 +75,11 @@ func (CommandExecutor) Execute(execution Execution) error {
 	cmd.Stdout = execution.Stdout
 	cmd.Stderr = execution.Stderr
 
-	return cmd.Run()
+	if err := cmd.Run(); err != nil{
+		if errors.Is(err, exec.ErrDot) {
+			return fmt.Errorf("the command %s would resolve relative to the current directory, this is disallowed in Go versions 1.19+", execution.Command)
+		}
+		return fmt.Errorf("unable to run command %s\n%w", execution.Command, err)
+	}
+	return nil
 }


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
To handle a change in Go 1.19: https://pkg.go.dev/os/exec#hdr-Executables_in_the_current_directory, `exec.Command` will return an error if the given command would resolve and run as `./<program>`.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
