### PR TITLE
Remove usage of ioutil/*

### DIFF
--- a/build_test.go
+++ b/build_test.go
@@ -18,7 +18,6 @@ package libpak_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -54,17 +53,17 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 	it.Before(func() {
 		var err error
 
-		applicationPath, err = ioutil.TempDir("", "build-application-path")
+		applicationPath = t.TempDir()
 		Expect(err).NotTo(HaveOccurred())
 		applicationPath, err = filepath.EvalSymlinks(applicationPath)
 		Expect(err).NotTo(HaveOccurred())
 
 		builder = &mocks.Builder{}
 
-		buildpackPath, err = ioutil.TempDir("", "build-buildpack-path")
+		buildpackPath = t.TempDir()
 		Expect(err).NotTo(HaveOccurred())
 
-		f, err := ioutil.TempFile("", "build-buildpackplan-path")
+		f, err := os.CreateTemp("", "build-buildpackplan-path")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(f.Close()).NotTo(HaveOccurred())
 		buildpackPlanPath = f.Name()
@@ -77,10 +76,10 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 		exitHandler = &mocks.ExitHandler{}
 		exitHandler.On("Error", mock.Anything)
 
-		layersPath, err = ioutil.TempDir("", "build-layers-path")
+		layersPath = t.TempDir()
 		Expect(err).NotTo(HaveOccurred())
 
-		platformPath, err = ioutil.TempDir("", "build-platform-path")
+		platformPath = t.TempDir()
 		Expect(err).NotTo(HaveOccurred())
 
 		tomlWriter = &mocks.TOMLWriter{}
@@ -105,7 +104,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 	})
 
 	it("handles error from Builder", func() {
-		Expect(ioutil.WriteFile(filepath.Join(buildpackPath, "buildpack.toml"), []byte(`
+		Expect(os.WriteFile(filepath.Join(buildpackPath, "buildpack.toml"), []byte(`
 api = "0.6"
 
 [buildpack]

--- a/carton/build_image_dependency.go
+++ b/carton/build_image_dependency.go
@@ -18,7 +18,6 @@ package carton
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"regexp"
 
@@ -48,7 +47,7 @@ func (i BuildImageDependency) Update(options ...Option) {
 	logger := bard.NewLogger(os.Stdout)
 	_, _ = fmt.Fprintf(logger.TitleWriter(), "\n%s\n", bard.FormatIdentity("Build Image", i.Version))
 
-	c, err := ioutil.ReadFile(i.BuilderPath)
+	c, err := os.ReadFile(i.BuilderPath)
 	if err != nil {
 		config.exitHandler.Error(fmt.Errorf("unable to read %s\n%w", i.BuilderPath, err))
 		return
@@ -64,7 +63,7 @@ func (i BuildImageDependency) Update(options ...Option) {
 	s := fmt.Sprintf(ImageDependencySubstitution, i.Version)
 	c = r.ReplaceAll(c, []byte(s))
 
-	if err := ioutil.WriteFile(i.BuilderPath, c, 0644); err != nil {
+	if err := os.WriteFile(i.BuilderPath, c, 0644); err != nil {
 		config.exitHandler.Error(fmt.Errorf("unable to write %s\n%w", i.BuilderPath, err))
 		return
 	}

--- a/carton/build_image_dependency_test.go
+++ b/carton/build_image_dependency_test.go
@@ -17,7 +17,6 @@
 package carton_test
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -43,7 +42,7 @@ func testBuildImageDependency(t *testing.T, context spec.G, it spec.S) {
 		exitHandler = &mocks.ExitHandler{}
 		exitHandler.On("Error", mock.Anything)
 
-		f, err := ioutil.TempFile("", "carton-image-dependency")
+		f, err := os.CreateTemp("", "carton-image-dependency")
 		Expect(err).NotTo(HaveOccurred())
 
 		_, err = f.WriteString(`test-prologue
@@ -67,7 +66,7 @@ test-epilogue
 
 		d.Update(carton.WithExitHandler(exitHandler))
 
-		Expect(ioutil.ReadFile(path)).To(Equal([]byte(`test-prologue
+		Expect(os.ReadFile(path)).To(Equal([]byte(`test-prologue
 build-image = "image-name:test-version-2"
 test-epilogue
 `)))

--- a/carton/buildpack_dependency.go
+++ b/carton/buildpack_dependency.go
@@ -19,7 +19,6 @@ package carton
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"regexp"
 
@@ -81,7 +80,7 @@ func (b BuildpackDependency) Update(options ...Option) {
 		return
 	}
 
-	c, err := ioutil.ReadFile(b.BuildpackPath)
+	c, err := os.ReadFile(b.BuildpackPath)
 	if err != nil {
 		config.exitHandler.Error(fmt.Errorf("unable to read %s\n%w", b.BuildpackPath, err))
 		return
@@ -187,7 +186,7 @@ func (b BuildpackDependency) Update(options ...Option) {
 
 	c = append(comments, c...)
 
-	if err := ioutil.WriteFile(b.BuildpackPath, c, 0644); err != nil {
+	if err := os.WriteFile(b.BuildpackPath, c, 0644); err != nil {
 		config.exitHandler.Error(fmt.Errorf("unable to write %s\n%w", b.BuildpackPath, err))
 		return
 	}

--- a/carton/buildpack_dependency_test.go
+++ b/carton/buildpack_dependency_test.go
@@ -17,7 +17,6 @@
 package carton_test
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -44,7 +43,7 @@ func testBuildpackDependency(t *testing.T, context spec.G, it spec.S) {
 		exitHandler = &mocks.ExitHandler{}
 		exitHandler.On("Error", mock.Anything)
 
-		f, err := ioutil.TempFile("", "carton-buildpack-dependency")
+		f, err := os.CreateTemp("", "carton-buildpack-dependency")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(f.Close()).To(Succeed())
 		path = f.Name()
@@ -55,7 +54,7 @@ func testBuildpackDependency(t *testing.T, context spec.G, it spec.S) {
 	})
 
 	it("updates dependency", func() {
-		Expect(ioutil.WriteFile(path, []byte(`api = "0.6"
+		Expect(os.WriteFile(path, []byte(`api = "0.6"
 [buildpack]
 id = "some-buildpack"
 name = "Some Buildpack"
@@ -81,7 +80,7 @@ stacks  = [ "test-stack" ]
 
 		d.Update(carton.WithExitHandler(exitHandler))
 
-		Expect(ioutil.ReadFile(path)).To(internal.MatchTOML(`api = "0.6"
+		Expect(os.ReadFile(path)).To(internal.MatchTOML(`api = "0.6"
 [buildpack]
 id = "some-buildpack"
 name = "Some Buildpack"
@@ -97,7 +96,7 @@ stacks  = [ "test-stack" ]
 	})
 
 	it("updates dependency with purl & cpes", func() {
-		Expect(ioutil.WriteFile(path, []byte(`api = "0.7"
+		Expect(os.WriteFile(path, []byte(`api = "0.7"
 [buildpack]
 id = "some-buildpack"
 name = "Some Buildpack"
@@ -129,7 +128,7 @@ cpes    = ["cpe:2.3:a:test-vendor:test-product:test-version-1:patch1:*:*:*:*:*:*
 
 		d.Update(carton.WithExitHandler(exitHandler))
 
-		Expect(ioutil.ReadFile(path)).To(internal.MatchTOML(`api = "0.7"
+		Expect(os.ReadFile(path)).To(internal.MatchTOML(`api = "0.7"
 [buildpack]
 id = "some-buildpack"
 name = "Some Buildpack"
@@ -147,7 +146,7 @@ cpes    = ["cpe:2.3:a:test-vendor:test-product:test-version-2:patch2:*:*:*:*:*:*
 	})
 
 	it("updates multiple dependencies with different versions", func() {
-		Expect(ioutil.WriteFile(path, []byte(`api = "0.7"
+		Expect(os.WriteFile(path, []byte(`api = "0.7"
 [buildpack]
 id = "some-buildpack"
 name = "Some Buildpack"
@@ -189,7 +188,7 @@ cpes    = ["cpe:2.3:a:test-vendor:test-product:test-version-2:patch2:*:*:*:*:*:*
 
 		d.Update(carton.WithExitHandler(exitHandler))
 
-		Expect(ioutil.ReadFile(path)).To(internal.MatchTOML(`api = "0.7"
+		Expect(os.ReadFile(path)).To(internal.MatchTOML(`api = "0.7"
 [buildpack]
 id = "some-buildpack"
 name = "Some Buildpack"
@@ -218,7 +217,7 @@ cpes    = ["cpe:2.3:a:test-vendor:test-product:test-version-2:patch2:*:*:*:*:*:*
 	})
 
 	it("updates dependency with missing purl, still updates cpe", func() {
-		Expect(ioutil.WriteFile(path, []byte(`api = "0.7"
+		Expect(os.WriteFile(path, []byte(`api = "0.7"
 [buildpack]
 id = "some-buildpack"
 name = "Some Buildpack"
@@ -249,7 +248,7 @@ cpes    = ["cpe:2.3:a:test-vendor:test-product:test-version-1:patch1:*:*:*:*:*:*
 
 		d.Update(carton.WithExitHandler(exitHandler))
 
-		Expect(ioutil.ReadFile(path)).To(internal.MatchTOML(`api = "0.7"
+		Expect(os.ReadFile(path)).To(internal.MatchTOML(`api = "0.7"
 [buildpack]
 id = "some-buildpack"
 name = "Some Buildpack"
@@ -266,7 +265,7 @@ cpes    = ["cpe:2.3:a:test-vendor:test-product:test-version-2:patch2:*:*:*:*:*:*
 	})
 
 	it("updates dependency with invalid purl, still updates cpe", func() {
-		Expect(ioutil.WriteFile(path, []byte(`api = "0.7"
+		Expect(os.WriteFile(path, []byte(`api = "0.7"
 [buildpack]
 id = "some-buildpack"
 name = "Some Buildpack"
@@ -298,7 +297,7 @@ cpes    = ["cpe:2.3:a:test-vendor:test-product:test-version-1:patch1:*:*:*:*:*:*
 
 		d.Update(carton.WithExitHandler(exitHandler))
 
-		Expect(ioutil.ReadFile(path)).To(internal.MatchTOML(`api = "0.7"
+		Expect(os.ReadFile(path)).To(internal.MatchTOML(`api = "0.7"
 [buildpack]
 id = "some-buildpack"
 name = "Some Buildpack"
@@ -316,7 +315,7 @@ cpes    = ["cpe:2.3:a:test-vendor:test-product:test-version-2:patch2:*:*:*:*:*:*
 	})
 
 	it("updates dependency with invalid cpe, still updates purl", func() {
-		Expect(ioutil.WriteFile(path, []byte(`api = "0.7"
+		Expect(os.WriteFile(path, []byte(`api = "0.7"
 [buildpack]
 id = "some-buildpack"
 name = "Some Buildpack"
@@ -348,7 +347,7 @@ cpes    = 1234
 
 		d.Update(carton.WithExitHandler(exitHandler))
 
-		Expect(ioutil.ReadFile(path)).To(internal.MatchTOML(`api = "0.7"
+		Expect(os.ReadFile(path)).To(internal.MatchTOML(`api = "0.7"
 [buildpack]
 id = "some-buildpack"
 name = "Some Buildpack"
@@ -366,7 +365,7 @@ cpes    = 1234
 	})
 
 	it("updates indented dependency", func() {
-		Expect(ioutil.WriteFile(path, []byte(`# it should preserve
+		Expect(os.WriteFile(path, []byte(`# it should preserve
 #   these comments
 #      exactly
 
@@ -396,7 +395,7 @@ version = "1.2.3"
 
 		d.Update(carton.WithExitHandler(exitHandler))
 
-		body, err := ioutil.ReadFile(path)
+		body, err := os.ReadFile(path)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(string(body)).To(HavePrefix(`# it should preserve
 #   these comments

--- a/carton/lifecycle_dependency.go
+++ b/carton/lifecycle_dependency.go
@@ -18,7 +18,6 @@ package carton
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"regexp"
 
@@ -48,7 +47,7 @@ func (l LifecycleDependency) Update(options ...Option) {
 	logger := bard.NewLogger(os.Stdout)
 	_, _ = fmt.Fprintf(logger.TitleWriter(), "\n%s\n", bard.FormatIdentity("Lifecycle", l.Version))
 
-	c, err := ioutil.ReadFile(l.BuilderPath)
+	c, err := os.ReadFile(l.BuilderPath)
 	if err != nil {
 		config.exitHandler.Error(fmt.Errorf("unable to read %s\n%w", l.BuilderPath, err))
 		return
@@ -64,7 +63,7 @@ func (l LifecycleDependency) Update(options ...Option) {
 	s := fmt.Sprintf(LifecycleDependencySubstitution, l.Version)
 	c = r.ReplaceAll(c, []byte(s))
 
-	if err := ioutil.WriteFile(l.BuilderPath, c, 0644); err != nil {
+	if err := os.WriteFile(l.BuilderPath, c, 0644); err != nil {
 		config.exitHandler.Error(fmt.Errorf("unable to write %s\n%w", l.BuilderPath, err))
 		return
 	}

--- a/carton/lifecycle_dependency_test.go
+++ b/carton/lifecycle_dependency_test.go
@@ -17,7 +17,6 @@
 package carton_test
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -43,7 +42,7 @@ func testLifecycleDependency(t *testing.T, context spec.G, it spec.S) {
 		exitHandler = &mocks.ExitHandler{}
 		exitHandler.On("Error", mock.Anything)
 
-		f, err := ioutil.TempFile("", "carton-builder-dependency")
+		f, err := os.CreateTemp("", "carton-builder-dependency")
 		Expect(err).NotTo(HaveOccurred())
 
 		_, err = f.WriteString(`test-prologue
@@ -70,7 +69,7 @@ test-epilogue
 
 		d.Update(carton.WithExitHandler(exitHandler))
 
-		Expect(ioutil.ReadFile(path)).To(Equal([]byte(`test-prologue
+		Expect(os.ReadFile(path)).To(Equal([]byte(`test-prologue
 
 [lifecycle]
 uri = "https://github.com/buildpacks/lifecycle/releases/download/vtest-version-3/lifecycle-vtest-version-3+linux.x86-64.tgz"

--- a/carton/netrc.go
+++ b/carton/netrc.go
@@ -18,7 +18,6 @@ package carton
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"os/user"
@@ -48,7 +47,7 @@ func (n Netrc) BasicAuth(request *http.Request) (*http.Request, error) {
 }
 
 func ParseNetrc(path string) (Netrc, error) {
-	b, err := ioutil.ReadFile(path)
+	b, err := os.ReadFile(path)
 	if os.IsNotExist(err) {
 		return nil, nil
 	} else if err != nil {

--- a/carton/netrc_test.go
+++ b/carton/netrc_test.go
@@ -17,7 +17,6 @@
 package carton_test
 
 import (
-	"io/ioutil"
 	"net/http"
 	"os"
 	"os/user"
@@ -40,7 +39,7 @@ func testNetrc(t *testing.T, context spec.G, it spec.S) {
 	it.Before(func() {
 		var err error
 
-		f, err := ioutil.TempFile("", "netrc")
+		f, err := os.CreateTemp("", "netrc")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(f.Close()).To(Succeed())
 		path = f.Name()
@@ -75,7 +74,7 @@ func testNetrc(t *testing.T, context spec.G, it spec.S) {
 
 	context("parse", func() {
 		it("parses one-liner", func() {
-			Expect(ioutil.WriteFile(path, []byte(`machine test-machine login test-login password test-password`), 0644)).To(Succeed())
+			Expect(os.WriteFile(path, []byte(`machine test-machine login test-login password test-password`), 0644)).To(Succeed())
 
 			Expect(carton.ParseNetrc(path)).To(Equal(carton.Netrc{
 				{
@@ -87,7 +86,7 @@ func testNetrc(t *testing.T, context spec.G, it spec.S) {
 		})
 
 		it("parses multi-liner", func() {
-			Expect(ioutil.WriteFile(path, []byte(`
+			Expect(os.WriteFile(path, []byte(`
 machine test-machine 
 login test-login 
 password test-password
@@ -103,7 +102,7 @@ password test-password
 		})
 
 		it("ignores macdef", func() {
-			Expect(ioutil.WriteFile(path, []byte(`
+			Expect(os.WriteFile(path, []byte(`
 macdef uploadtest
 	cd /pub/tests
 	bin
@@ -123,7 +122,7 @@ machine test-machine login test-login password test-password
 		})
 
 		it("ignores all after default", func() {
-			Expect(ioutil.WriteFile(path, []byte(`
+			Expect(os.WriteFile(path, []byte(`
 machine test-machine-1 login test-login-1 password test-password-1
 
 default

--- a/carton/package.go
+++ b/carton/package.go
@@ -18,7 +18,6 @@ package carton
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -81,7 +80,7 @@ func (p Package) Create(options ...Option) {
 
 	buildpack := libcnb.Buildpack{}
 	file = filepath.Join(p.Source, "buildpack.toml")
-	b, err := ioutil.ReadFile(file)
+	b, err := os.ReadFile(file)
 	if err != nil && !os.IsNotExist(err) {
 		config.exitHandler.Error(fmt.Errorf("unable to read %s\n%w", file, err))
 		return
@@ -115,7 +114,7 @@ func (p Package) Create(options ...Option) {
 			return
 		}
 
-		out, err := ioutil.TempFile("", "buildpack-*.toml")
+		out, err := os.CreateTemp("", "buildpack-*.toml")
 		if err != nil {
 			config.exitHandler.Error(fmt.Errorf("unable to open temporary buildpack.toml file\n%w", err))
 		}

--- a/carton/package_dependency.go
+++ b/carton/package_dependency.go
@@ -19,7 +19,6 @@ package carton
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -140,7 +139,7 @@ func updateByKey(key, id, version string) func(md map[string]interface{}) {
 }
 
 func updateFile(cfgPath string, f func(md map[string]interface{})) error {
-	c, err := ioutil.ReadFile(cfgPath)
+	c, err := os.ReadFile(cfgPath)
 	if err != nil {
 		return fmt.Errorf("unable to read %s\n%w", cfgPath, err)
 	}
@@ -170,7 +169,7 @@ func updateFile(cfgPath string, f func(md map[string]interface{})) error {
 
 	b = append(comments, b...)
 
-	if err := ioutil.WriteFile(cfgPath, b, 0644); err != nil {
+	if err := os.WriteFile(cfgPath, b, 0644); err != nil {
 		return fmt.Errorf("unable to write %s\n%w", cfgPath, err)
 	}
 

--- a/carton/package_dependency_test.go
+++ b/carton/package_dependency_test.go
@@ -17,7 +17,6 @@
 package carton_test
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -44,7 +43,7 @@ func testPackageDependency(t *testing.T, context spec.G, it spec.S) {
 		exitHandler = &mocks.ExitHandler{}
 		exitHandler.On("Error", mock.Anything)
 
-		f, err := ioutil.TempFile("", "carton-package-dependency")
+		f, err := os.CreateTemp("", "carton-package-dependency")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(f.Close()).To(Succeed())
 		path = f.Name()
@@ -55,7 +54,7 @@ func testPackageDependency(t *testing.T, context spec.G, it spec.S) {
 	})
 
 	it("updates paketo-buildpacks dependency without losing other fields", func() {
-		Expect(ioutil.WriteFile(path, []byte(`# it should preserve
+		Expect(os.WriteFile(path, []byte(`# it should preserve
 #   these comments
 #      exactly
 
@@ -84,7 +83,7 @@ include-files = [
 
 		p.Update(carton.WithExitHandler(exitHandler))
 
-		body, err := ioutil.ReadFile(path)
+		body, err := os.ReadFile(path)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(string(body)).To(HavePrefix(`# it should preserve
 #   these comments
@@ -110,7 +109,7 @@ include-files = [
 	})
 
 	it("updates paketo-buildpacks dependency id partial id", func() {
-		Expect(ioutil.WriteFile(path, []byte(`
+		Expect(os.WriteFile(path, []byte(`
 [[order]]
 group = [
 	{ id = "paketo-buildpacks/test-1", version="test-version-1" },
@@ -125,7 +124,7 @@ group = [
 
 		p.Update(carton.WithExitHandler(exitHandler))
 
-		Expect(ioutil.ReadFile(path)).To(internal.MatchTOML(`[[order]]
+		Expect(os.ReadFile(path)).To(internal.MatchTOML(`[[order]]
 group = [
 	{ id = "paketo-buildpacks/test-1", version="test-version-3" },
 	{ id = "paketo-buildpacks/test-2", version="test-version-2" },
@@ -133,7 +132,7 @@ group = [
 	})
 
 	it("updates paketocommunity dependency", func() {
-		Expect(ioutil.WriteFile(path, []byte(`[[order]]
+		Expect(os.WriteFile(path, []byte(`[[order]]
 group = [
 	{ id = "paketocommunity/test-1", version="test-version-1" },
 	{ id = "paketocommunity/test-2", version="test-version-2" },
@@ -147,7 +146,7 @@ group = [
 
 		p.Update(carton.WithExitHandler(exitHandler))
 
-		Expect(ioutil.ReadFile(path)).To(internal.MatchTOML(`[[order]]
+		Expect(os.ReadFile(path)).To(internal.MatchTOML(`[[order]]
 group = [
 	{ id = "paketocommunity/test-1", version="test-version-3" },
 	{ id = "paketocommunity/test-2", version="test-version-2" },
@@ -155,7 +154,7 @@ group = [
 	})
 
 	it("updates builder dependency", func() {
-		Expect(ioutil.WriteFile(path, []byte(`buildpacks = [
+		Expect(os.WriteFile(path, []byte(`buildpacks = [
 	{ id = "paketo-buildpacks/test-1", uri = "docker://gcr.io/paketo-buildpacks/test-1:test-version-1" },
 	{ id = "paketo-buildpacks/test-2", uri = "docker://gcr.io/paketo-buildpacks/test-2:test-version-2" },
 ]`), 0644)).To(Succeed())
@@ -168,14 +167,14 @@ group = [
 
 		p.Update(carton.WithExitHandler(exitHandler))
 
-		Expect(ioutil.ReadFile(path)).To(internal.MatchTOML(`buildpacks = [
+		Expect(os.ReadFile(path)).To(internal.MatchTOML(`buildpacks = [
 	{ id = "paketo-buildpacks/test-1", uri = "docker://gcr.io/paketo-buildpacks/test-1:test-version-3" },
 	{ id = "paketo-buildpacks/test-2", uri = "docker://gcr.io/paketo-buildpacks/test-2:test-version-2" },
 ]`))
 	})
 
 	it("updates paketo-buildpacks package dependency", func() {
-		Expect(ioutil.WriteFile(path, []byte(`dependencies = [
+		Expect(os.WriteFile(path, []byte(`dependencies = [
 	{ uri = "docker://gcr.io/paketo-buildpacks/test-1:test-version-1" },
 	{ uri = "docker://gcr.io/paketo-buildpacks/test-2:test-version-2" },
 ]`), 0644)).To(Succeed())
@@ -188,14 +187,14 @@ group = [
 
 		p.Update(carton.WithExitHandler(exitHandler))
 
-		Expect(ioutil.ReadFile(path)).To(internal.MatchTOML(`dependencies = [
+		Expect(os.ReadFile(path)).To(internal.MatchTOML(`dependencies = [
 	{ uri = "docker://gcr.io/paketo-buildpacks/test-1:test-version-3" },
 	{ uri = "docker://gcr.io/paketo-buildpacks/test-2:test-version-2" },
 ]`))
 	})
 
 	it("updates paketocommunity package dependency", func() {
-		Expect(ioutil.WriteFile(path, []byte(`dependencies = [
+		Expect(os.WriteFile(path, []byte(`dependencies = [
 	{ uri = "docker://docker.io/paketocommunity/test-1:test-version-1" },
 	{ uri = "docker://docker.io/paketocommunity/test-2:test-version-2" },
 ]`), 0644)).To(Succeed())
@@ -208,7 +207,7 @@ group = [
 
 		p.Update(carton.WithExitHandler(exitHandler))
 
-		Expect(ioutil.ReadFile(path)).To(internal.MatchTOML(`dependencies = [
+		Expect(os.ReadFile(path)).To(internal.MatchTOML(`dependencies = [
 	{ uri = "docker://docker.io/paketocommunity/test-1:test-version-3" },
 	{ uri = "docker://docker.io/paketocommunity/test-2:test-version-2" },
 ]`))

--- a/carton/package_test.go
+++ b/carton/package_test.go
@@ -17,7 +17,6 @@
 package carton_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -44,8 +43,6 @@ func testPackage(t *testing.T, context spec.G, it spec.S) {
 	)
 
 	it.Before(func() {
-		var err error
-
 		entryWriter = &cMocks.EntryWriter{}
 		entryWriter.On("Write", mock.Anything, mock.Anything).Return(nil)
 
@@ -55,10 +52,9 @@ func testPackage(t *testing.T, context spec.G, it spec.S) {
 		exitHandler = &mocks.ExitHandler{}
 		exitHandler.On("Error", mock.Anything)
 
-		path, err = ioutil.TempDir("", "carton-package")
-		Expect(err).NotTo(HaveOccurred())
+		path = t.TempDir()
 
-		Expect(ioutil.WriteFile(filepath.Join(path, "buildpack.toml"), []byte(`
+		Expect(os.WriteFile(filepath.Join(path, "buildpack.toml"), []byte(`
 api = "0.0.0"
 
 [buildpack]
@@ -134,7 +130,7 @@ include-files = [
 		Expect(entryWriter.Calls[1].Arguments[0]).To(Equal(filepath.Join(path, "test-include-files")))
 		Expect(entryWriter.Calls[1].Arguments[1]).To(Equal(filepath.Join("test-destination", "test-include-files")))
 
-		Expect(ioutil.ReadFile(entryWriter.Calls[0].Arguments[0].(string))).To(Equal([]byte(`
+		Expect(os.ReadFile(entryWriter.Calls[0].Arguments[0].(string))).To(Equal([]byte(`
 api = "0.0.0"
 
 [buildpack]
@@ -164,7 +160,7 @@ include-files = [
 
 	context("includes dependencies", func() {
 		it.Before(func() {
-			Expect(ioutil.WriteFile(filepath.Join(path, "buildpack.toml"), []byte(`
+			Expect(os.WriteFile(filepath.Join(path, "buildpack.toml"), []byte(`
 api = "0.0.0"
 
 [buildpack]

--- a/crush/crush_test.go
+++ b/crush/crush_test.go
@@ -17,7 +17,6 @@
 package crush_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -30,20 +29,11 @@ import (
 
 func testCrush(t *testing.T, context spec.G, it spec.S) {
 	var (
-		Expect = NewWithT(t).Expect
-
 		path string
 	)
 
 	it.Before(func() {
-		var err error
-
-		path, err = ioutil.TempDir("", "crush")
-		Expect(err).NotTo(HaveOccurred())
-	})
-
-	it.After(func() {
-		Expect(os.RemoveAll(path)).To(Succeed())
+		path = t.TempDir()
 	})
 
 	context("Create", func() {
@@ -56,11 +46,10 @@ func testCrush(t *testing.T, context spec.G, it spec.S) {
 		it.Before(func() {
 			var err error
 
-			out, err = ioutil.TempFile("", "crush-tar")
+			out, err = os.CreateTemp("", "crush-tar")
 			Expect(err).NotTo(HaveOccurred())
 
-			testPath, err = ioutil.TempDir("", "crush-tar")
-			Expect(err).NotTo(HaveOccurred())
+			testPath = t.TempDir()
 		})
 
 		it.After(func() {
@@ -70,10 +59,10 @@ func testCrush(t *testing.T, context spec.G, it spec.S) {
 		})
 
 		it("writes a TAR", func() {
-			Expect(ioutil.WriteFile(filepath.Join(path, "fileA.txt"), []byte(""), 0644)).To(Succeed())
+			Expect(os.WriteFile(filepath.Join(path, "fileA.txt"), []byte(""), 0644)).To(Succeed())
 			Expect(os.MkdirAll(filepath.Join(path, "dirA"), 0755)).To(Succeed())
-			Expect(ioutil.WriteFile(filepath.Join(path, "dirA", "fileB.txt"), []byte(""), 0644)).To(Succeed())
-			Expect(ioutil.WriteFile(filepath.Join(path, "dirA", "fileC.txt"), []byte(""), 0644)).To(Succeed())
+			Expect(os.WriteFile(filepath.Join(path, "dirA", "fileB.txt"), []byte(""), 0644)).To(Succeed())
+			Expect(os.WriteFile(filepath.Join(path, "dirA", "fileC.txt"), []byte(""), 0644)).To(Succeed())
 			Expect(os.Symlink(filepath.Join(path, "dirA", "fileC.txt"), filepath.Join(path, "dirA", "fileD.txt"))).To(Succeed())
 
 			Expect(crush.CreateTar(out, path)).To(Succeed())
@@ -89,10 +78,10 @@ func testCrush(t *testing.T, context spec.G, it spec.S) {
 		})
 
 		it("writes a TAR.GZ", func() {
-			Expect(ioutil.WriteFile(filepath.Join(path, "fileA.txt"), []byte(""), 0644)).To(Succeed())
+			Expect(os.WriteFile(filepath.Join(path, "fileA.txt"), []byte(""), 0644)).To(Succeed())
 			Expect(os.MkdirAll(filepath.Join(path, "dirA"), 0755)).To(Succeed())
-			Expect(ioutil.WriteFile(filepath.Join(path, "dirA", "fileB.txt"), []byte(""), 0644)).To(Succeed())
-			Expect(ioutil.WriteFile(filepath.Join(path, "dirA", "fileC.txt"), []byte(""), 0644)).To(Succeed())
+			Expect(os.WriteFile(filepath.Join(path, "dirA", "fileB.txt"), []byte(""), 0644)).To(Succeed())
+			Expect(os.WriteFile(filepath.Join(path, "dirA", "fileC.txt"), []byte(""), 0644)).To(Succeed())
 			Expect(os.Symlink(filepath.Join(path, "dirA", "fileC.txt"), filepath.Join(path, "dirA", "fileD.txt"))).To(Succeed())
 
 			Expect(crush.CreateTarGz(out, path)).To(Succeed())

--- a/dependency_cache.go
+++ b/dependency_cache.go
@@ -21,7 +21,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -131,7 +130,7 @@ func (d *DependencyCache) Artifact(dependency BuildpackDependency, mods ...Reque
 	}
 
 	file = filepath.Join(d.CachePath, fmt.Sprintf("%s.toml", dependency.SHA256))
-	b, err := ioutil.ReadFile(file)
+	b, err := os.ReadFile(file)
 	if err != nil && !os.IsNotExist(err) {
 		return nil, fmt.Errorf("unable to read %s\n%w", file, err)
 	}
@@ -145,7 +144,7 @@ func (d *DependencyCache) Artifact(dependency BuildpackDependency, mods ...Reque
 	}
 
 	file = filepath.Join(d.DownloadPath, fmt.Sprintf("%s.toml", dependency.SHA256))
-	b, err = ioutil.ReadFile(file)
+	b, err = os.ReadFile(file)
 	if err != nil && !os.IsNotExist(err) {
 		return nil, fmt.Errorf("unable to read %s\n%w", file, err)
 	}

--- a/dependency_cache_test.go
+++ b/dependency_cache_test.go
@@ -19,7 +19,6 @@ package libpak_test
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -131,10 +130,10 @@ func testDependencyCache(t *testing.T, context spec.G, it spec.S) {
 		it.Before(func() {
 			var err error
 
-			cachePath, err = ioutil.TempDir("", "dependency-cache-cache-path")
+			cachePath = t.TempDir()
 			Expect(err).NotTo(HaveOccurred())
 
-			downloadPath, err = ioutil.TempDir("", "dependency-cache-download-path")
+			downloadPath = t.TempDir()
 			Expect(err).NotTo(HaveOccurred())
 
 			RegisterTestingT(t)
@@ -200,7 +199,7 @@ func testDependencyCache(t *testing.T, context spec.G, it spec.S) {
 			a, err := dependencyCache.Artifact(dependency)
 			Expect(err).NotTo(HaveOccurred())
 
-			Expect(ioutil.ReadAll(a)).To(Equal([]byte("test-fixture")))
+			Expect(io.ReadAll(a)).To(Equal([]byte("test-fixture")))
 		})
 
 		it("returns from download path", func() {
@@ -210,7 +209,7 @@ func testDependencyCache(t *testing.T, context spec.G, it spec.S) {
 			a, err := dependencyCache.Artifact(dependency)
 			Expect(err).NotTo(HaveOccurred())
 
-			Expect(ioutil.ReadAll(a)).To(Equal([]byte("test-fixture")))
+			Expect(io.ReadAll(a)).To(Equal([]byte("test-fixture")))
 		})
 
 		it("downloads", func() {
@@ -222,7 +221,7 @@ func testDependencyCache(t *testing.T, context spec.G, it spec.S) {
 			a, err := dependencyCache.Artifact(dependency)
 			Expect(err).NotTo(HaveOccurred())
 
-			Expect(ioutil.ReadAll(a)).To(Equal([]byte("test-fixture")))
+			Expect(io.ReadAll(a)).To(Equal([]byte("test-fixture")))
 		})
 
 		context("uri is overridden HTTP", func() {
@@ -241,16 +240,15 @@ func testDependencyCache(t *testing.T, context spec.G, it spec.S) {
 				a, err := dependencyCache.Artifact(dependency)
 				Expect(err).NotTo(HaveOccurred())
 
-				Expect(ioutil.ReadAll(a)).To(Equal([]byte("test-fixture")))
+				Expect(io.ReadAll(a)).To(Equal([]byte("test-fixture")))
 			})
 		})
 
 		context("uri is overridden FILE", func() {
 			it.Before(func() {
-				sourcePath, err := ioutil.TempDir("", "dependency-source-path")
-				Expect(err).NotTo(HaveOccurred())
+				sourcePath := t.TempDir()
 				sourceFile := filepath.Join(sourcePath, "source-file")
-				Expect(ioutil.WriteFile(sourceFile, []byte("test-fixture"), 0644)).ToNot(HaveOccurred())
+				Expect(os.WriteFile(sourceFile, []byte("test-fixture"), 0644)).ToNot(HaveOccurred())
 
 				dependencyCache.Mappings = map[string]string{
 					dependency.SHA256: fmt.Sprintf("file://%s", sourceFile),
@@ -261,7 +259,7 @@ func testDependencyCache(t *testing.T, context spec.G, it spec.S) {
 				a, err := dependencyCache.Artifact(dependency)
 				Expect(err).NotTo(HaveOccurred())
 
-				Expect(ioutil.ReadAll(a)).To(Equal([]byte("test-fixture")))
+				Expect(io.ReadAll(a)).To(Equal([]byte("test-fixture")))
 			})
 		})
 
@@ -284,7 +282,7 @@ func testDependencyCache(t *testing.T, context spec.G, it spec.S) {
 			a, err := dependencyCache.Artifact(dependency)
 			Expect(err).NotTo(HaveOccurred())
 
-			Expect(ioutil.ReadAll(a)).To(Equal([]byte("alternate-fixture")))
+			Expect(io.ReadAll(a)).To(Equal([]byte("alternate-fixture")))
 		})
 
 		it("sets User-Agent", func() {
@@ -296,7 +294,7 @@ func testDependencyCache(t *testing.T, context spec.G, it spec.S) {
 			a, err := dependencyCache.Artifact(dependency)
 			Expect(err).NotTo(HaveOccurred())
 
-			Expect(ioutil.ReadAll(a)).To(Equal([]byte("test-fixture")))
+			Expect(io.ReadAll(a)).To(Equal([]byte("test-fixture")))
 		})
 
 		it("modifies request", func() {
@@ -312,7 +310,7 @@ func testDependencyCache(t *testing.T, context spec.G, it spec.S) {
 			})
 			Expect(err).NotTo(HaveOccurred())
 
-			Expect(ioutil.ReadAll(a)).To(Equal([]byte("test-fixture")))
+			Expect(io.ReadAll(a)).To(Equal([]byte("test-fixture")))
 		})
 	})
 }

--- a/detect_test.go
+++ b/detect_test.go
@@ -18,7 +18,6 @@ package libpak_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -52,15 +51,13 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 	it.Before(func() {
 		var err error
 
-		applicationPath, err = ioutil.TempDir("", "detect-application-path")
-		Expect(err).NotTo(HaveOccurred())
+		applicationPath = t.TempDir()
 		applicationPath, err = filepath.EvalSymlinks(applicationPath)
 		Expect(err).NotTo(HaveOccurred())
 
-		buildpackPath, err = ioutil.TempDir("", "detect-buildpack-path")
-		Expect(err).NotTo(HaveOccurred())
+		buildpackPath = t.TempDir()
 
-		f, err := ioutil.TempFile("", "detect-buildplan-path")
+		f, err := os.CreateTemp("", "detect-buildplan-path")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(f.Close()).NotTo(HaveOccurred())
 		buildPlanPath = f.Name()
@@ -74,8 +71,7 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 		exitHandler.On("Fail")
 		exitHandler.On("Pass")
 
-		platformPath, err = ioutil.TempDir("", "detect-platform-path")
-		Expect(err).NotTo(HaveOccurred())
+		platformPath = t.TempDir()
 
 		tomlWriter = &mocks.TOMLWriter{}
 		tomlWriter.On("Write", mock.Anything, mock.Anything).Return(nil)
@@ -99,7 +95,7 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 	})
 
 	it("handles error from Detector", func() {
-		Expect(ioutil.WriteFile(filepath.Join(buildpackPath, "buildpack.toml"), []byte(`
+		Expect(os.WriteFile(filepath.Join(buildpackPath, "buildpack.toml"), []byte(`
 api = "0.6"
 
 [buildpack]

--- a/internal/entry_writer_test.go
+++ b/internal/entry_writer_test.go
@@ -17,7 +17,6 @@
 package internal_test
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -42,14 +41,14 @@ func testEntryWriter(t *testing.T, context spec.G, it spec.S) {
 			f   *os.File
 		)
 
-		f, err = ioutil.TempFile("", "entry-writer-source")
+		f, err = os.CreateTemp("", "entry-writer-source")
 		Expect(err).NotTo(HaveOccurred())
 		_, err = f.WriteString("test-value")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(f.Close()).To(Succeed())
 		source = f.Name()
 
-		f, err = ioutil.TempFile("", "entry-writer-destination")
+		f, err = os.CreateTemp("", "entry-writer-destination")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(f.Close()).To(Succeed())
 		Expect(os.RemoveAll(f.Name())).To(Succeed())
@@ -65,7 +64,7 @@ func testEntryWriter(t *testing.T, context spec.G, it spec.S) {
 
 	it("writes file", func() {
 		Expect(writer.Write(source, destination)).To(Succeed())
-		Expect(ioutil.ReadFile(destination)).To(Equal([]byte("test-value")))
+		Expect(os.ReadFile(destination)).To(Equal([]byte("test-value")))
 	})
 
 	it("sets executable bit", func() {
@@ -84,7 +83,7 @@ func testEntryWriter(t *testing.T, context spec.G, it spec.S) {
 		)
 
 		it.Before(func() {
-			f, err := ioutil.TempFile("", "entry-writer-symlink-source")
+			f, err := os.CreateTemp("", "entry-writer-symlink-source")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(f.Close()).To(Succeed())
 			Expect(os.RemoveAll(f.Name())).To(Succeed())

--- a/internal/environment_writer.go
+++ b/internal/environment_writer.go
@@ -18,7 +18,6 @@ package internal
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -80,7 +79,7 @@ func (w EnvironmentWriter) Write(path string, environment map[string]string) err
 			return fmt.Errorf("unable to mkdir from key %s\n%w", filepath.Dir(f), err)
 		}
 
-		if err := ioutil.WriteFile(f, []byte(environment[k]), 0644); err != nil {
+		if err := os.WriteFile(f, []byte(environment[k]), 0644); err != nil {
 			return fmt.Errorf("unable to write file %s\n%w", f, err)
 		}
 	}

--- a/internal/environment_writer_test.go
+++ b/internal/environment_writer_test.go
@@ -18,7 +18,6 @@ package internal_test
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -39,16 +38,10 @@ func testEnvironmentWriter(t *testing.T, context spec.G, it spec.S) {
 	)
 
 	it.Before(func() {
-		var err error
-		path, err = ioutil.TempDir("", "environment-writer")
-		Expect(err).NotTo(HaveOccurred())
+		path = t.TempDir()
 		Expect(os.RemoveAll(path)).To(Succeed())
 
 		writer = internal.EnvironmentWriter{}
-	})
-
-	it.After(func() {
-		Expect(os.RemoveAll(path)).To(Succeed())
 	})
 
 	it("writes the given environment to a directory", func() {
@@ -58,11 +51,11 @@ func testEnvironmentWriter(t *testing.T, context spec.G, it spec.S) {
 		})
 		Expect(err).NotTo(HaveOccurred())
 
-		content, err := ioutil.ReadFile(filepath.Join(path, "some-name"))
+		content, err := os.ReadFile(filepath.Join(path, "some-name"))
 		Expect(err).NotTo(HaveOccurred())
 		Expect(string(content)).To(Equal("some-content"))
 
-		content, err = ioutil.ReadFile(filepath.Join(path, "other-name"))
+		content, err = os.ReadFile(filepath.Join(path, "other-name"))
 		Expect(err).NotTo(HaveOccurred())
 		Expect(string(content)).To(Equal("other-content"))
 	})
@@ -73,7 +66,7 @@ func testEnvironmentWriter(t *testing.T, context spec.G, it spec.S) {
 		})
 		Expect(err).NotTo(HaveOccurred())
 
-		content, err := ioutil.ReadFile(filepath.Join(path, "some-proc", "some-name"))
+		content, err := os.ReadFile(filepath.Join(path, "some-proc", "some-name"))
 		Expect(err).NotTo(HaveOccurred())
 		Expect(string(content)).To(Equal("some-content"))
 	})

--- a/internal/toml_writer_test.go
+++ b/internal/toml_writer_test.go
@@ -19,7 +19,6 @@ package internal_test
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -43,15 +42,8 @@ func testTOMLWriter(t *testing.T, context spec.G, it spec.S) {
 	)
 
 	it.Before(func() {
-		var err error
-		parent, err = ioutil.TempDir("", "toml-writer")
-		Expect(err).NotTo(HaveOccurred())
-
+		parent = t.TempDir()
 		path = filepath.Join(parent, "text.toml")
-	})
-
-	it.After(func() {
-		Expect(os.RemoveAll(parent)).To(Succeed())
 	})
 
 	it("writes the contents of a given object out to a .toml file", func() {
@@ -61,7 +53,7 @@ func testTOMLWriter(t *testing.T, context spec.G, it spec.S) {
 		})
 		Expect(err).NotTo(HaveOccurred())
 
-		Expect(ioutil.ReadFile(path)).To(internal.MatchTOML(`
+		Expect(os.ReadFile(path)).To(internal.MatchTOML(`
 some-field = "some-value"
 other-field = "other-value"`))
 	})

--- a/layer_test.go
+++ b/layer_test.go
@@ -18,7 +18,6 @@ package libpak_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -43,10 +42,7 @@ func testLayer(t *testing.T, context spec.G, it spec.S) {
 	)
 
 	it.Before(func() {
-		var err error
-
-		layersDir, err = ioutil.TempDir("", "layer")
-		Expect(err).NotTo(HaveOccurred())
+		layersDir = t.TempDir()
 		layer.Path = filepath.Join(layersDir, "test-layer")
 
 		layer.Exec.Path = layer.Path
@@ -113,7 +109,7 @@ func testLayer(t *testing.T, context spec.G, it spec.S) {
 			})
 
 			it("calls function with matching metadata but no layer directory on cache layer", func() {
-				Expect(ioutil.WriteFile(fmt.Sprintf("%s.toml", layer.Path), []byte{}, 0644)).To(Succeed())
+				Expect(os.WriteFile(fmt.Sprintf("%s.toml", layer.Path), []byte{}, 0644)).To(Succeed())
 				Expect(os.RemoveAll(layer.Path)).To(Succeed())
 				lc.ExpectedTypes.Cache = true
 
@@ -127,7 +123,7 @@ func testLayer(t *testing.T, context spec.G, it spec.S) {
 			})
 
 			it("calls function with matching metadata but no layer directory on build layer", func() {
-				Expect(ioutil.WriteFile(fmt.Sprintf("%s.toml", layer.Path), []byte{}, 0644)).To(Succeed())
+				Expect(os.WriteFile(fmt.Sprintf("%s.toml", layer.Path), []byte{}, 0644)).To(Succeed())
 				Expect(os.RemoveAll(layer.Path)).To(Succeed())
 				lc.ExpectedTypes.Build = true
 
@@ -141,7 +137,7 @@ func testLayer(t *testing.T, context spec.G, it spec.S) {
 			})
 
 			it("calls function with matching metadata but an empty layer directory on build layer", func() {
-				Expect(ioutil.WriteFile(fmt.Sprintf("%s.toml", layer.Path), []byte{}, 0644)).To(Succeed())
+				Expect(os.WriteFile(fmt.Sprintf("%s.toml", layer.Path), []byte{}, 0644)).To(Succeed())
 				Expect(os.MkdirAll(layer.Path, 0755)).To(Succeed())
 				lc.ExpectedTypes.Build = true
 
@@ -155,9 +151,9 @@ func testLayer(t *testing.T, context spec.G, it spec.S) {
 			})
 
 			it("does not call function with matching metadata when layer directory exists and has a file in it", func() {
-				Expect(ioutil.WriteFile(fmt.Sprintf("%s.toml", layer.Path), []byte{}, 0644)).To(Succeed())
+				Expect(os.WriteFile(fmt.Sprintf("%s.toml", layer.Path), []byte{}, 0644)).To(Succeed())
 				Expect(os.MkdirAll(layer.Path, 0755)).To(Succeed())
-				Expect(ioutil.WriteFile(filepath.Join(layer.Path, "foo"), []byte{}, 0644)).To(Succeed())
+				Expect(os.WriteFile(filepath.Join(layer.Path, "foo"), []byte{}, 0644)).To(Succeed())
 				lc.ExpectedTypes.Build = true
 
 				_, err := lc.Contribute(layer, func() (libcnb.Layer, error) {
@@ -597,7 +593,7 @@ func testLayer(t *testing.T, context spec.G, it spec.S) {
 			outputFile := layer.SBOMPath(libcnb.SyftJSON)
 			Expect(outputFile).To(BeARegularFile())
 
-			data, err := ioutil.ReadFile(outputFile)
+			data, err := os.ReadFile(outputFile)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(string(data)).To(ContainSubstring(`"Artifacts":[`))
 			Expect(string(data)).To(ContainSubstring(`"FoundBy":"libpak",`))
@@ -657,8 +653,6 @@ func testLayer(t *testing.T, context spec.G, it spec.S) {
 		)
 
 		it.Before(func() {
-			var err error
-
 			buildpack.Info = libcnb.BuildpackInfo{
 				ID:       "test-id",
 				Name:     "test-name",
@@ -666,14 +660,12 @@ func testLayer(t *testing.T, context spec.G, it spec.S) {
 				Homepage: "test-homepage",
 			}
 
-			buildpack.Path, err = ioutil.TempDir("", "buildpack")
-			Expect(err).NotTo(HaveOccurred())
-
+			buildpack.Path = t.TempDir()
 			file := filepath.Join(buildpack.Path, "bin")
 			Expect(os.MkdirAll(file, 0755)).To(Succeed())
 
 			file = filepath.Join(file, "helper")
-			Expect(ioutil.WriteFile(file, []byte{}, 0755)).To(Succeed())
+			Expect(os.WriteFile(file, []byte{}, 0755)).To(Succeed())
 
 			hlc = libpak.HelperLayerContributor{
 				Path:          file,
@@ -787,7 +779,7 @@ func testLayer(t *testing.T, context spec.G, it spec.S) {
 			outputFile := layer.SBOMPath(libcnb.SyftJSON)
 			Expect(outputFile).To(BeARegularFile())
 
-			data, err := ioutil.ReadFile(outputFile)
+			data, err := os.ReadFile(outputFile)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(string(data)).To(ContainSubstring(`"Artifacts":[`))
 			Expect(string(data)).To(ContainSubstring(`"FoundBy":"libpak",`))

--- a/main_test.go
+++ b/main_test.go
@@ -17,7 +17,6 @@
 package libpak_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -53,18 +52,16 @@ func testMain(t *testing.T, context spec.G, it spec.S) {
 	it.Before(func() {
 		var err error
 
-		applicationPath, err = ioutil.TempDir("", "main-application-path")
-		Expect(err).NotTo(HaveOccurred())
+		applicationPath = t.TempDir()
 		applicationPath, err = filepath.EvalSymlinks(applicationPath)
 		Expect(err).NotTo(HaveOccurred())
 
 		builder = &mocks.Builder{}
 
-		buildpackPath, err = ioutil.TempDir("", "main-buildpack-path")
-		Expect(err).NotTo(HaveOccurred())
+		buildpackPath = t.TempDir()
 		Expect(os.Setenv("CNB_BUILDPACK_DIR", buildpackPath)).To(Succeed())
 
-		Expect(ioutil.WriteFile(filepath.Join(buildpackPath, "buildpack.toml"),
+		Expect(os.WriteFile(filepath.Join(buildpackPath, "buildpack.toml"),
 			[]byte(`
 api = "0.6"
 
@@ -90,12 +87,12 @@ test-key = "test-value"
 			0644),
 		).To(Succeed())
 
-		f, err := ioutil.TempFile("", "main-buildpackplan-path")
+		f, err := os.CreateTemp("", "main-buildpackplan-path")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(f.Close()).NotTo(HaveOccurred())
 		buildpackPlanPath = f.Name()
 
-		Expect(ioutil.WriteFile(buildpackPlanPath,
+		Expect(os.WriteFile(buildpackPlanPath,
 			[]byte(`
 [[entries]]
 name = "test-name"
@@ -107,7 +104,7 @@ test-key = "test-value"
 			0644),
 		).To(Succeed())
 
-		f, err = ioutil.TempFile("", "main-buildplan-path")
+		f, err = os.CreateTemp("", "main-buildplan-path")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(f.Close()).NotTo(HaveOccurred())
 		buildPlanPath = f.Name()
@@ -122,10 +119,9 @@ test-key = "test-value"
 		exitHandler.On("Pass", mock.Anything)
 		exitHandler.On("Fail", mock.Anything)
 
-		layersPath, err = ioutil.TempDir("", "main-layers-path")
-		Expect(err).NotTo(HaveOccurred())
+		layersPath = t.TempDir()
 
-		Expect(ioutil.WriteFile(filepath.Join(layersPath, "store.toml"),
+		Expect(os.WriteFile(filepath.Join(layersPath, "store.toml"),
 			[]byte(`
 [metadata]
 test-key = "test-value"
@@ -133,24 +129,23 @@ test-key = "test-value"
 			0644),
 		).To(Succeed())
 
-		platformPath, err = ioutil.TempDir("", "main-platform-path")
-		Expect(err).NotTo(HaveOccurred())
+		platformPath = t.TempDir()
 
 		Expect(os.MkdirAll(filepath.Join(platformPath, "bindings", "alpha", "metadata"), 0755)).To(Succeed())
-		Expect(ioutil.WriteFile(
+		Expect(os.WriteFile(
 			filepath.Join(platformPath, "bindings", "alpha", "metadata", "test-metadata-key"),
 			[]byte("test-metadata-value"),
 			0644,
 		)).To(Succeed())
 		Expect(os.MkdirAll(filepath.Join(platformPath, "bindings", "alpha", "secret"), 0755)).To(Succeed())
-		Expect(ioutil.WriteFile(
+		Expect(os.WriteFile(
 			filepath.Join(platformPath, "bindings", "alpha", "secret", "test-secret-key"),
 			[]byte("test-secret-value"),
 			0644,
 		)).To(Succeed())
 
 		Expect(os.MkdirAll(filepath.Join(platformPath, "env"), 0755)).To(Succeed())
-		Expect(ioutil.WriteFile(filepath.Join(platformPath, "env", "TEST_ENV"), []byte("test-value"), 0644)).
+		Expect(os.WriteFile(filepath.Join(platformPath, "env", "TEST_ENV"), []byte("test-value"), 0644)).
 			To(Succeed())
 
 		tomlWriter = &mocks.TOMLWriter{}

--- a/sbom/sbom.go
+++ b/sbom/sbom.go
@@ -3,7 +3,6 @@ package sbom
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"github.com/buildpacks/libcnb"
@@ -51,7 +50,7 @@ func (s SyftDependency) WriteTo(path string) error {
 		return fmt.Errorf("unable to marshal to JSON\n%w", err)
 	}
 
-	err = ioutil.WriteFile(path, output, 0644)
+	err = os.WriteFile(path, output, 0644)
 	if err != nil {
 		return fmt.Errorf("unable to write to path %s\n%w", path, err)
 	}

--- a/sherpa/copy_file_test.go
+++ b/sherpa/copy_file_test.go
@@ -17,7 +17,6 @@
 package sherpa_test
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -38,7 +37,7 @@ func testCopyFile(t *testing.T, context spec.G, it spec.S) {
 	it.Before(func() {
 		var err error
 
-		source, err = ioutil.TempFile("", "copy-file")
+		source, err = os.CreateTemp("", "copy-file")
 		Expect(err).NotTo(HaveOccurred())
 		_, err = source.WriteString("test")
 		Expect(err).NotTo(HaveOccurred())
@@ -46,7 +45,7 @@ func testCopyFile(t *testing.T, context spec.G, it spec.S) {
 		source, err = os.Open(source.Name())
 		Expect(err).NotTo(HaveOccurred())
 
-		f, err := ioutil.TempFile("", "copy-file")
+		f, err := os.CreateTemp("", "copy-file")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(f.Close()).To(Succeed())
 		destination = f.Name()
@@ -60,6 +59,6 @@ func testCopyFile(t *testing.T, context spec.G, it spec.S) {
 	it("create listing", func() {
 		defer source.Close()
 		Expect(sherpa.CopyFile(source, destination)).To(Succeed())
-		Expect(ioutil.ReadFile(destination)).To(Equal([]byte("test")))
+		Expect(os.ReadFile(destination)).To(Equal([]byte("test")))
 	})
 }

--- a/sherpa/exists_test.go
+++ b/sherpa/exists_test.go
@@ -17,7 +17,6 @@
 package sherpa_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -35,13 +34,7 @@ func testExists(t *testing.T, when spec.G, it spec.S) {
 	)
 
 	it.Before(func() {
-		var err error
-		testPath, err = ioutil.TempDir("", "exists")
-		Expect(err).NotTo(HaveOccurred())
-	})
-
-	it.After(func() {
-		Expect(os.RemoveAll(testPath)).To(Succeed())
+		testPath = t.TempDir()
 	})
 
 	when("checking something exists", func() {

--- a/sherpa/file_listing_test.go
+++ b/sherpa/file_listing_test.go
@@ -19,7 +19,6 @@ package sherpa_test
 import (
 	"crypto/sha256"
 	"encoding/hex"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -38,20 +37,13 @@ func testFileListing(t *testing.T, context spec.G, it spec.S) {
 	)
 
 	it.Before(func() {
-		var err error
-
-		path, err = ioutil.TempDir("", "file-listing")
-		Expect(err).NotTo(HaveOccurred())
-	})
-
-	it.After(func() {
-		Expect(os.RemoveAll(path)).To(Succeed())
+		path = t.TempDir()
 	})
 
 	it("create listing", func() {
-		Expect(ioutil.WriteFile(filepath.Join(path, "alpha.txt"), []byte{1}, 0644)).To(Succeed())
+		Expect(os.WriteFile(filepath.Join(path, "alpha.txt"), []byte{1}, 0644)).To(Succeed())
 		Expect(os.MkdirAll(filepath.Join(path, "test-directory"), 0755)).To(Succeed())
-		Expect(ioutil.WriteFile(filepath.Join(path, "test-directory", "bravo.txt"), []byte{2}, 0644)).To(Succeed())
+		Expect(os.WriteFile(filepath.Join(path, "test-directory", "bravo.txt"), []byte{2}, 0644)).To(Succeed())
 
 		e, err := sherpa.NewFileListing(path)
 		Expect(err).NotTo(HaveOccurred())
@@ -61,13 +53,13 @@ func testFileListing(t *testing.T, context spec.G, it spec.S) {
 
 	it("create listing skipping .git folder", func() {
 		Expect(os.MkdirAll(filepath.Join(path, ".git"), 0755)).To(Succeed())
-		Expect(ioutil.WriteFile(filepath.Join(path, ".git", "HEAD"), []byte{1}, 0644)).To(Succeed())
-		Expect(ioutil.WriteFile(filepath.Join(path, ".git", "config"), []byte{1}, 0644)).To(Succeed())
-		Expect(ioutil.WriteFile(filepath.Join(path, "alpha.txt"), []byte{1}, 0644)).To(Succeed())
+		Expect(os.WriteFile(filepath.Join(path, ".git", "HEAD"), []byte{1}, 0644)).To(Succeed())
+		Expect(os.WriteFile(filepath.Join(path, ".git", "config"), []byte{1}, 0644)).To(Succeed())
+		Expect(os.WriteFile(filepath.Join(path, "alpha.txt"), []byte{1}, 0644)).To(Succeed())
 		Expect(os.MkdirAll(filepath.Join(path, "test-directory"), 0755)).To(Succeed())
-		Expect(ioutil.WriteFile(filepath.Join(path, "test-directory", "bravo.txt"), []byte{2}, 0644)).To(Succeed())
+		Expect(os.WriteFile(filepath.Join(path, "test-directory", "bravo.txt"), []byte{2}, 0644)).To(Succeed())
 		Expect(os.MkdirAll(filepath.Join(path, "test-directory", ".git"), 0755)).To(Succeed())
-		Expect(ioutil.WriteFile(filepath.Join(path, "test-directory", ".git", "config"), []byte{1}, 0644)).To(Succeed())
+		Expect(os.WriteFile(filepath.Join(path, "test-directory", ".git", "config"), []byte{1}, 0644)).To(Succeed())
 
 		e, err := sherpa.NewFileListing(path)
 		Expect(err).NotTo(HaveOccurred())
@@ -76,9 +68,9 @@ func testFileListing(t *testing.T, context spec.G, it spec.S) {
 	})
 
 	it("create listing as hash with non-regular file", func() {
-		Expect(ioutil.WriteFile(filepath.Join(path, "alpha.txt"), []byte{1}, 0644)).To(Succeed())
+		Expect(os.WriteFile(filepath.Join(path, "alpha.txt"), []byte{1}, 0644)).To(Succeed())
 		Expect(os.MkdirAll(filepath.Join(path, "test-directory"), 0755)).To(Succeed())
-		Expect(ioutil.WriteFile(filepath.Join(path, "test-directory", "bravo.txt"), []byte{2}, 0644)).To(Succeed())
+		Expect(os.WriteFile(filepath.Join(path, "test-directory", "bravo.txt"), []byte{2}, 0644)).To(Succeed())
 		Expect(os.Symlink(filepath.Join(path, "test-directory"), filepath.Join(path, "symlink-test-dir")))
 		Expect(os.Symlink(filepath.Join(path, "test-directory", "bravo.txt"), filepath.Join(path, "symlink-bravo.txt")))
 		Expect(os.Symlink("alpha.txt", filepath.Join(path, "symlink-relative.txt")))
@@ -97,9 +89,9 @@ func testFileListing(t *testing.T, context spec.G, it spec.S) {
 	})
 
 	it("create listing and get SHA256", func() {
-		Expect(ioutil.WriteFile(filepath.Join(path, "alpha.txt"), []byte{}, 0644)).To(Succeed())
+		Expect(os.WriteFile(filepath.Join(path, "alpha.txt"), []byte{}, 0644)).To(Succeed())
 		Expect(os.MkdirAll(filepath.Join(path, "test-directory"), 0755)).To(Succeed())
-		Expect(ioutil.WriteFile(filepath.Join(path, "test-directory", "bravo.txt"), []byte{}, 0644)).To(Succeed())
+		Expect(os.WriteFile(filepath.Join(path, "test-directory", "bravo.txt"), []byte{}, 0644)).To(Succeed())
 
 		e, err := sherpa.NewFileListing(path)
 		Expect(err).NotTo(HaveOccurred())

--- a/sherpa/nodejs_test.go
+++ b/sherpa/nodejs_test.go
@@ -17,7 +17,6 @@
 package sherpa_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -36,14 +35,7 @@ func testNodeJS(t *testing.T, context spec.G, it spec.S) {
 	)
 
 	it.Before(func() {
-		var err error
-
-		path, err = ioutil.TempDir("", "nodejs")
-		Expect(err).NotTo(HaveOccurred())
-	})
-
-	it.After(func() {
-		Expect(os.RemoveAll(path)).To(Succeed())
+		path = t.TempDir()
 	})
 
 	it("returns server.js if no package.json exists", func() {
@@ -51,13 +43,13 @@ func testNodeJS(t *testing.T, context spec.G, it spec.S) {
 	})
 
 	it("returns server.js if package.json does not have a main entry", func() {
-		Expect(ioutil.WriteFile(filepath.Join(path, "package.json"), []byte(`{}`), 0644)).To(Succeed())
+		Expect(os.WriteFile(filepath.Join(path, "package.json"), []byte(`{}`), 0644)).To(Succeed())
 
 		Expect(sherpa.NodeJSMainModule(path)).To(Equal("server.js"))
 	})
 
 	it("returns main module", func() {
-		Expect(ioutil.WriteFile(filepath.Join(path, "package.json"), []byte(`{ "main": "test-main" }`), 0644)).
+		Expect(os.WriteFile(filepath.Join(path, "package.json"), []byte(`{ "main": "test-main" }`), 0644)).
 			To(Succeed())
 
 		Expect(sherpa.NodeJSMainModule(path)).To(Equal("test-main"))


### PR DESCRIPTION
## Summary

Remove `ioutil` usage to be compatible with Go 1.20.

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
