### PR TITLE
Set sensible http client timeout

### DIFF
--- a/dependency_cache.go
+++ b/dependency_cache.go
@@ -27,7 +27,6 @@ import (
 	"path/filepath"
 	"reflect"
 	"strings"
-	"time"
 
 	"github.com/buildpacks/libcnb"
 	"github.com/heroku/color"
@@ -241,10 +240,7 @@ func (d DependencyCache) downloadHttp(uri string, destination string, mods ...Re
 		}
 	}
 
-	client := http.Client{
-		Transport: &http.Transport{Proxy: http.ProxyFromEnvironment},
-		Timeout:   time.Minute * 1,
-	}
+	client := http.Client{}
 	resp, err := client.Do(req)
 	if err != nil {
 		return fmt.Errorf("unable to request %s\n%w", uri, err)

--- a/dependency_cache.go
+++ b/dependency_cache.go
@@ -27,6 +27,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"strings"
+	"time"
 
 	"github.com/buildpacks/libcnb"
 	"github.com/heroku/color"
@@ -240,7 +241,10 @@ func (d DependencyCache) downloadHttp(uri string, destination string, mods ...Re
 		}
 	}
 
-	client := http.Client{Transport: &http.Transport{Proxy: http.ProxyFromEnvironment}}
+	client := http.Client{
+		Transport: &http.Transport{Proxy: http.ProxyFromEnvironment},
+		Timeout:   time.Minute * 1,
+	}
 	resp, err := client.Do(req)
 	if err != nil {
 		return fmt.Errorf("unable to request %s\n%w", uri, err)


### PR DESCRIPTION
Set the default HTTP client timeout to 1 minute.  This avoids extremely long timeouts.

<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
Go defaults to having no timeout on http connections.  In environments where a proxy setting is incorrectly configured, this can cause an excessive wait before we see a "unable to download" message.

## Use Cases
Ensure we fail quickly when downloading assets in misconfigured environments.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
