### PR TITLE
Add Predicate `WithName` to filter bindings

### DIFF
--- a/bindings/resolve.go
+++ b/bindings/resolve.go
@@ -30,7 +30,7 @@ type Predicate func(bind libcnb.Binding) bool
 // case-insensitive.
 func OfType(t string) Predicate {
 	return func(bind libcnb.Binding) bool {
-		return strings.ToLower(bind.Type) == strings.ToLower(t)
+		return strings.EqualFold(bind.Type, t)
 	}
 }
 
@@ -38,7 +38,15 @@ func OfType(t string) Predicate {
 // case-insensitive.
 func OfProvider(p string) Predicate {
 	return func(bind libcnb.Binding) bool {
-		return strings.ToLower(bind.Provider) == strings.ToLower(p)
+		return strings.EqualFold(bind.Provider, p)
+	}
+}
+
+// WithName returns a Predicate that returns true if a given binding has Name that matches n. The comparison is
+// case-insensitive.
+func WithName(n string) Predicate {
+	return func(bind libcnb.Binding) bool {
+		return strings.EqualFold(bind.Name, n)
 	}
 }
 
@@ -46,9 +54,8 @@ func OfProvider(p string) Predicate {
 func Resolve(binds libcnb.Bindings, predicates ...Predicate) libcnb.Bindings {
 	var result libcnb.Bindings
 	// deep copy
-	for _, bind := range binds {
-		result = append(result, bind)
-	}
+	result = append(result, binds...)
+
 	// filter on predicates
 	for _, p := range predicates {
 		result = filter(result, p)

--- a/bindings/resolve_test.go
+++ b/bindings/resolve_test.go
@@ -50,6 +50,11 @@ func testResolve(t *testing.T, context spec.G, it spec.S) {
 				Type:     "other-type",
 				Provider: "some-provider",
 			},
+			{
+				Name:     "name1",
+				Type:     "unknown",
+				Provider: "unknown",
+			},
 		}
 	})
 
@@ -96,6 +101,26 @@ func testResolve(t *testing.T, context spec.G, it spec.S) {
 						Name:     "name3",
 						Type:     "other-type",
 						Provider: "some-provider",
+					},
+				}))
+			})
+		})
+
+		context("WithName", func() {
+			it("returns all with matching name", func() {
+				resolved := bindings.Resolve(binds,
+					bindings.WithName("Name1"),
+				)
+				Expect(resolved).To(Equal(libcnb.Bindings{
+					{
+						Name:     "name1",
+						Type:     "some-type",
+						Provider: "some-provider",
+					},
+					{
+						Name:     "name1",
+						Type:     "unknown",
+						Provider: "unknown",
 					},
 				}))
 			})


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->
see https://github.com/buildpacks/libcnb/pull/228

## Summary
<!-- A short explanation of the proposed change -->
Being able to get a binding with a specific name could be useful in specific situation.

## Use Cases
<!-- An explanation of the use cases your change enables -->
If the bindings are read from `VCAP_SERVICES` and the binding is a "user-provided-service", then the type would always be `user-provided`. So resolving it by type makes no sense, but resolving it by name should be fine since the user can choose the name when creating a "user-provided-service".

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
