### PR TITLE
Add customizable timeout settings for the HTTP Client

### DIFF
--- a/dependency_cache_test.go
+++ b/dependency_cache_test.go
@@ -62,6 +62,36 @@ func testDependencyCache(t *testing.T, context spec.G, it spec.S) {
 			Expect(dependencyCache.Mappings).To(Equal(map[string]string{}))
 		})
 
+		it("uses default timeout values", func() {
+			dependencyCache, err := libpak.NewDependencyCache(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(dependencyCache.HttpClientTimeouts.DialerTimeout).To(Equal(6 * time.Second))
+			Expect(dependencyCache.HttpClientTimeouts.DialerKeepAlive).To(Equal(60 * time.Second))
+			Expect(dependencyCache.HttpClientTimeouts.TLSHandshakeTimeout).To(Equal(5 * time.Second))
+			Expect(dependencyCache.HttpClientTimeouts.ResponseHeaderTimeout).To(Equal(5 * time.Second))
+			Expect(dependencyCache.HttpClientTimeouts.ExpectContinueTimeout).To(Equal(1 * time.Second))
+		})
+
+		context("custom timeout setttings", func() {
+			it.Before(func() {
+				t.Setenv("BP_DIALER_TIMEOUT", "7")
+				t.Setenv("BP_DIALER_KEEP_ALIVE", "50")
+				t.Setenv("BP_TLS_HANDSHAKE_TIMEOUT", "2")
+				t.Setenv("BP_RESPONSE_HEADER_TIMEOUT", "3")
+				t.Setenv("BP_EXPECT_CONTINUE_TIMEOUT", "2")
+			})
+
+			it("uses custom timeout values", func() {
+				dependencyCache, err := libpak.NewDependencyCache(ctx)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(dependencyCache.HttpClientTimeouts.DialerTimeout).To(Equal(7 * time.Second))
+				Expect(dependencyCache.HttpClientTimeouts.DialerKeepAlive).To(Equal(50 * time.Second))
+				Expect(dependencyCache.HttpClientTimeouts.TLSHandshakeTimeout).To(Equal(2 * time.Second))
+				Expect(dependencyCache.HttpClientTimeouts.ResponseHeaderTimeout).To(Equal(3 * time.Second))
+				Expect(dependencyCache.HttpClientTimeouts.ExpectContinueTimeout).To(Equal(2 * time.Second))
+			})
+		})
+
 		context("bindings with type dependencies exist", func() {
 			it.Before(func() {
 				ctx.Platform.Bindings = libcnb.Bindings{


### PR DESCRIPTION
## Summary

Adds customizable timeout settings to the HTTP client.

## Use Cases

Superceeds https://github.com/paketo-buildpacks/libpak/pull/236

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
