### PR TITLE
Updates for Release 2.x (Rename Buildpack to BuildModule for common paths)

### DIFF
--- a/buildmodule.go
+++ b/buildmodule.go
@@ -113,7 +113,7 @@ func (b1 BuildModuleDependency) Equals(b2 BuildModuleDependency) bool {
 }
 
 // AsSyftArtifact renders a bill of materials entry describing the dependency as Syft.
-func (b BuildModuleDependency) AsSyftArtifact() (sbom.SyftArtifact, error) {
+func (b BuildModuleDependency) AsSyftArtifact(source string) (sbom.SyftArtifact, error) {
 	licenses := []string{}
 	for _, license := range b.Licenses {
 		licenses = append(licenses, license.Type)
@@ -125,7 +125,7 @@ func (b BuildModuleDependency) AsSyftArtifact() (sbom.SyftArtifact, error) {
 		Type:      "UnknownPackage",
 		FoundBy:   "libpak",
 		Licenses:  licenses,
-		Locations: []sbom.SyftLocation{{Path: "buildpack.toml"}}, // TODO this needs to alter based on xtn/bp
+		Locations: []sbom.SyftLocation{{Path: source}},
 		CPEs:      b.CPEs,
 		PURL:      b.PURL,
 	}

--- a/buildmodule.go
+++ b/buildmodule.go
@@ -34,7 +34,7 @@ import (
 )
 
 // BuildpackConfiguration represents a build or launch configuration parameter.
-type BuildpackConfiguration struct {
+type BuildModuleConfiguration struct {
 
 	// Build indicates whether the configuration is for build-time.  Optional.
 	Build bool `toml:"build"`
@@ -52,9 +52,9 @@ type BuildpackConfiguration struct {
 	Name string `toml:"name"`
 }
 
-// BuildpackDependencyLicense represents a license that a BuildpackDependency is distributed under.  At least one of
+// BuildModuleDependencyLicense represents a license that a BuildModuleDependency is distributed under.  At least one of
 // Name or URI MUST be specified.
-type BuildpackDependencyLicense struct {
+type BuildModuleDependencyLicense struct {
 
 	// Type is the type of the license.  This is typically the SPDX short identifier.
 	Type string `toml:"type"`
@@ -63,8 +63,8 @@ type BuildpackDependencyLicense struct {
 	URI string `toml:"uri"`
 }
 
-// BuildpackDependency describes a dependency known to the buildpack.
-type BuildpackDependency struct {
+// BuildModuleDependency describes a dependency known to the buildpack/extension
+type BuildModuleDependency struct {
 	// ID is the dependency ID.
 	ID string `toml:"id"`
 
@@ -84,7 +84,7 @@ type BuildpackDependency struct {
 	Stacks []string `toml:"stacks"`
 
 	// Licenses are the licenses the dependency is distributed under.
-	Licenses []BuildpackDependencyLicense `toml:"licenses"`
+	Licenses []BuildModuleDependencyLicense `toml:"licenses"`
 
 	// CPEs are the Common Platform Enumeration identifiers for the dependency
 	CPEs []string `toml:"cpes"`
@@ -98,7 +98,7 @@ type BuildpackDependency struct {
 
 // Equals compares the 2 structs if they are equal. This is very simiar to reflect.DeepEqual
 // except that properties that will not work (e.g. DeprecationDate) are ignored.
-func (b1 BuildpackDependency) Equals(b2 BuildpackDependency) bool {
+func (b1 BuildModuleDependency) Equals(b2 BuildModuleDependency) bool {
 	b1.DeprecationDate = b1.DeprecationDate.Truncate(time.Second).In(time.UTC)
 	b2.DeprecationDate = b2.DeprecationDate.Truncate(time.Second).In(time.UTC)
 
@@ -113,7 +113,7 @@ func (b1 BuildpackDependency) Equals(b2 BuildpackDependency) bool {
 }
 
 // AsSyftArtifact renders a bill of materials entry describing the dependency as Syft.
-func (b BuildpackDependency) AsSyftArtifact() (sbom.SyftArtifact, error) {
+func (b BuildModuleDependency) AsSyftArtifact() (sbom.SyftArtifact, error) {
 	licenses := []string{}
 	for _, license := range b.Licenses {
 		licenses = append(licenses, license.Type)
@@ -125,7 +125,7 @@ func (b BuildpackDependency) AsSyftArtifact() (sbom.SyftArtifact, error) {
 		Type:      "UnknownPackage",
 		FoundBy:   "libpak",
 		Licenses:  licenses,
-		Locations: []sbom.SyftLocation{{Path: "buildpack.toml"}},
+		Locations: []sbom.SyftLocation{{Path: "buildpack.toml"}}, // TODO this needs to alter based on xtn/bp
 		CPEs:      b.CPEs,
 		PURL:      b.PURL,
 	}
@@ -139,27 +139,27 @@ func (b BuildpackDependency) AsSyftArtifact() (sbom.SyftArtifact, error) {
 	return sbomArtifact, nil
 }
 
-func (b BuildpackDependency) IsDeprecated() bool {
+func (b BuildModuleDependency) IsDeprecated() bool {
 	deprecationDate := b.DeprecationDate.UTC()
 	now := time.Now().UTC()
 	return deprecationDate.Equal(now) || deprecationDate.Before(now)
 }
 
-func (b BuildpackDependency) IsSoonDeprecated() bool {
+func (b BuildModuleDependency) IsSoonDeprecated() bool {
 	deprecationDate := b.DeprecationDate.UTC()
 	now := time.Now().UTC()
 	return deprecationDate.Add(-30*24*time.Hour).Before(now) && deprecationDate.After(now)
 }
 
-// BuildpackMetadata is an extension to libcnb.Buildpack's metadata with opinions.
-type BuildpackMetadata struct {
+// BuildpackMetadata is an extension to libcnb.Buildpack / libcnb.Extension's metadata with opinions.
+type BuildModuleMetadata struct {
 
 	// Configurations are environment variables that can be used at build time to configure the buildpack and launch
 	// time to configure the application.
-	Configurations []BuildpackConfiguration
+	Configurations []BuildModuleConfiguration
 
 	// Dependencies are the dependencies known to the buildpack.
-	Dependencies []BuildpackDependency
+	Dependencies []BuildModuleDependency
 
 	// IncludeFiles describes the files to include in the package.
 	IncludeFiles []string
@@ -169,12 +169,12 @@ type BuildpackMetadata struct {
 }
 
 // NewBuildpackMetadata creates a new instance of BuildpackMetadata from the contents of libcnb.Buildpack.Metadata
-func NewBuildpackMetadata(metadata map[string]interface{}) (BuildpackMetadata, error) {
-	m := BuildpackMetadata{}
+func NewBuildModuleMetadata(metadata map[string]interface{}) (BuildModuleMetadata, error) {
+	m := BuildModuleMetadata{}
 
 	if v, ok := metadata["configurations"]; ok {
 		for _, v := range v.([]map[string]interface{}) {
-			var c BuildpackConfiguration
+			var c BuildModuleConfiguration
 
 			if v, ok := v["build"].(bool); ok {
 				c.Build = v
@@ -202,7 +202,7 @@ func NewBuildpackMetadata(metadata map[string]interface{}) (BuildpackMetadata, e
 
 	if v, ok := metadata["dependencies"]; ok {
 		for _, v := range v.([]map[string]interface{}) {
-			var d BuildpackDependency
+			var d BuildModuleDependency
 
 			if v, ok := v["id"].(string); ok {
 				d.ID = v
@@ -232,7 +232,7 @@ func NewBuildpackMetadata(metadata map[string]interface{}) (BuildpackMetadata, e
 
 			if v, ok := v["licenses"].([]map[string]interface{}); ok {
 				for _, v := range v {
-					var l BuildpackDependencyLicense
+					var l BuildModuleDependencyLicense
 
 					if v, ok := v["type"].(string); ok {
 						l.Type = v
@@ -260,7 +260,7 @@ func NewBuildpackMetadata(metadata map[string]interface{}) (BuildpackMetadata, e
 				deprecationDate, err := time.Parse(time.RFC3339, v)
 
 				if err != nil {
-					return BuildpackMetadata{}, fmt.Errorf("unable to parse deprecation date\n%w", err)
+					return BuildModuleMetadata{}, fmt.Errorf("unable to parse deprecation date\n%w", err)
 				}
 
 				d.DeprecationDate = deprecationDate
@@ -287,7 +287,7 @@ func NewBuildpackMetadata(metadata map[string]interface{}) (BuildpackMetadata, e
 type ConfigurationResolver struct {
 
 	// Configurations are the configurations to resolve against
-	Configurations []BuildpackConfiguration
+	Configurations []BuildModuleConfiguration
 }
 
 type configurationEntry struct {
@@ -323,7 +323,7 @@ func (c configurationEntry) String(nameLength int, valueLength int) string {
 // NewConfigurationResolver creates a new instance from buildpack metadata.  Logs configuration options to the body
 // level int the form 'Set $Name to configure $Description[. Default <i>$Default</i>.]'.
 func NewConfigurationResolver(buildpack libcnb.Buildpack, logger *bard.Logger) (ConfigurationResolver, error) {
-	md, err := NewBuildpackMetadata(buildpack.Metadata)
+	md, err := NewBuildModuleMetadata(buildpack.Metadata)
 	if err != nil {
 		return ConfigurationResolver{}, fmt.Errorf("unable to unmarshal buildpack metadata\n%w", err)
 	}
@@ -434,7 +434,7 @@ func (c *ConfigurationResolver) ResolveBool(name string) bool {
 type DependencyResolver struct {
 
 	// Dependencies are the dependencies to resolve against.
-	Dependencies []BuildpackDependency
+	Dependencies []BuildModuleDependency
 
 	// StackID is the stack id of the build.
 	StackID string
@@ -445,7 +445,7 @@ type DependencyResolver struct {
 
 // NewDependencyResolver creates a new instance from the buildpack metadata and stack id.
 func NewDependencyResolver(context libcnb.BuildContext) (DependencyResolver, error) {
-	md, err := NewBuildpackMetadata(context.Buildpack.Metadata)
+	md, err := NewBuildModuleMetadata(context.Buildpack.Metadata)
 	if err != nil {
 		return DependencyResolver{}, fmt.Errorf("unable to unmarshal buildpack metadata\n%w", err)
 	}
@@ -472,21 +472,21 @@ func IsNoValidDependencies(err error) bool {
 // Resolve returns the latest version of a dependency within the collection of Dependencies.  The candidate set is first
 // filtered by the constraints, then the remaining candidates are sorted for the latest result by semver semantics.
 // Version can contain wildcards and defaults to "*" if not specified.
-func (d *DependencyResolver) Resolve(id string, version string) (BuildpackDependency, error) {
+func (d *DependencyResolver) Resolve(id string, version string) (BuildModuleDependency, error) {
 	if version == "" {
 		version = "*"
 	}
 
 	vc, err := semver.NewConstraint(version)
 	if err != nil {
-		return BuildpackDependency{}, fmt.Errorf("invalid constraint %s\n%w", vc, err)
+		return BuildModuleDependency{}, fmt.Errorf("invalid constraint %s\n%w", vc, err)
 	}
 
-	var candidates []BuildpackDependency
+	var candidates []BuildModuleDependency
 	for _, c := range d.Dependencies {
 		v, err := semver.NewVersion(c.Version)
 		if err != nil {
-			return BuildpackDependency{}, fmt.Errorf("unable to parse version %s\n%w", c.Version, err)
+			return BuildModuleDependency{}, fmt.Errorf("unable to parse version %s\n%w", c.Version, err)
 		}
 
 		if c.ID == id && vc.Check(v) && d.contains(c.Stacks, d.StackID) {
@@ -495,7 +495,7 @@ func (d *DependencyResolver) Resolve(id string, version string) (BuildpackDepend
 	}
 
 	if len(candidates) == 0 {
-		return BuildpackDependency{}, NoValidDependenciesError{
+		return BuildModuleDependency{}, NoValidDependenciesError{
 			Message: fmt.Sprintf("no valid dependencies for %s, %s, and %s in %s",
 				id, version, d.StackID, DependenciesFormatter(d.Dependencies)),
 		}
@@ -531,7 +531,7 @@ func (DependencyResolver) contains(candidates []string, value string) bool {
 	return false
 }
 
-func (d *DependencyResolver) printDependencyDeprecation(dependency BuildpackDependency) {
+func (d *DependencyResolver) printDependencyDeprecation(dependency BuildModuleDependency) {
 	if d.Logger == nil {
 		return
 	}

--- a/buildmodule_test.go
+++ b/buildmodule_test.go
@@ -40,7 +40,7 @@ func testBuildpack(t *testing.T, context spec.G, it spec.S) {
 	)
 
 	it("is equal after toml Marshal and Unmarshal", func() {
-		dependency := libpak.BuildpackDependency{
+		dependency := libpak.BuildModuleDependency{
 			ID:              "test-id",
 			Name:            "test-name",
 			Version:         "1.1.1",
@@ -48,7 +48,7 @@ func testBuildpack(t *testing.T, context spec.G, it spec.S) {
 			SHA256:          "test-sha256",
 			DeprecationDate: time.Now(),
 			Stacks:          []string{"test-stack"},
-			Licenses: []libpak.BuildpackDependencyLicense{
+			Licenses: []libpak.BuildModuleDependencyLicense{
 				{
 					Type: "test-type",
 					URI:  "test-uri",
@@ -59,7 +59,7 @@ func testBuildpack(t *testing.T, context spec.G, it spec.S) {
 		bytes, err := internal.Marshal(dependency)
 		Expect(err).NotTo(HaveOccurred())
 
-		var newDependency libpak.BuildpackDependency
+		var newDependency libpak.BuildModuleDependency
 		err = toml.Unmarshal(bytes, &newDependency)
 		Expect(err).NotTo(HaveOccurred())
 
@@ -67,14 +67,14 @@ func testBuildpack(t *testing.T, context spec.G, it spec.S) {
 	})
 
 	it("renders dependency as a SyftArtifact", func() {
-		dependency := libpak.BuildpackDependency{
+		dependency := libpak.BuildModuleDependency{
 			ID:      "test-id",
 			Name:    "test-name",
 			Version: "1.1.1",
 			URI:     "test-uri",
 			SHA256:  "test-sha256",
 			Stacks:  []string{"test-stack"},
-			Licenses: []libpak.BuildpackDependencyLicense{
+			Licenses: []libpak.BuildModuleDependencyLicense{
 				{
 					Type: "test-type",
 					URI:  "test-uri",
@@ -98,12 +98,12 @@ func testBuildpack(t *testing.T, context spec.G, it spec.S) {
 	})
 
 	it("calculates dependency deprecation", func() {
-		deprecatedDependency := libpak.BuildpackDependency{
+		deprecatedDependency := libpak.BuildModuleDependency{
 			ID:              "test-id",
 			DeprecationDate: time.Now().UTC(),
 		}
 
-		soonDeprecatedDependency := libpak.BuildpackDependency{
+		soonDeprecatedDependency := libpak.BuildModuleDependency{
 			ID:              "test-id",
 			DeprecationDate: time.Now().UTC().Add(30 * 24 * time.Hour),
 		}
@@ -150,15 +150,15 @@ func testBuildpack(t *testing.T, context spec.G, it spec.S) {
 			deprecationDate, err := time.Parse(time.RFC3339, "2021-12-31T15:59:00-08:00")
 			Expect(err).ToNot(HaveOccurred())
 
-			expected := libpak.BuildpackMetadata{
-				Configurations: []libpak.BuildpackConfiguration{
+			expected := libpak.BuildModuleMetadata{
+				Configurations: []libpak.BuildModuleConfiguration{
 					{
 						Name:        "test-name",
 						Default:     "test-default",
 						Description: "test-description",
 					},
 				},
-				Dependencies: []libpak.BuildpackDependency{
+				Dependencies: []libpak.BuildModuleDependency{
 					{
 						ID:      "test-id",
 						Name:    "test-name",
@@ -166,7 +166,7 @@ func testBuildpack(t *testing.T, context spec.G, it spec.S) {
 						URI:     "test-uri",
 						SHA256:  "test-sha256",
 						Stacks:  []string{"test-stack"},
-						Licenses: []libpak.BuildpackDependencyLicense{
+						Licenses: []libpak.BuildModuleDependencyLicense{
 							{
 								Type: "test-type",
 								URI:  "test-uri",
@@ -181,14 +181,14 @@ func testBuildpack(t *testing.T, context spec.G, it spec.S) {
 				PrePackage:   "test-pre-package",
 			}
 
-			Expect(libpak.NewBuildpackMetadata(actual)).To(Equal(expected))
+			Expect(libpak.NewBuildModuleMetadata(actual)).To(Equal(expected))
 		})
 	})
 
 	context("ConfigurationResolver", func() {
 		var (
 			resolver = libpak.ConfigurationResolver{
-				Configurations: []libpak.BuildpackConfiguration{
+				Configurations: []libpak.BuildModuleConfiguration{
 					{Name: "TEST_KEY_1", Default: "test-default-value-1"},
 					{Name: "TEST_KEY_2", Default: "test-default-value-2"},
 					{Name: "TEST_BOOL_3", Default: "true"},
@@ -255,7 +255,7 @@ func testBuildpack(t *testing.T, context spec.G, it spec.S) {
 		context("Resolve", func() {
 
 			it("filters by id", func() {
-				resolver.Dependencies = []libpak.BuildpackDependency{
+				resolver.Dependencies = []libpak.BuildModuleDependency{
 					{
 						ID:      "test-id-1",
 						Name:    "test-name",
@@ -275,7 +275,7 @@ func testBuildpack(t *testing.T, context spec.G, it spec.S) {
 				}
 				resolver.StackID = "test-stack-1"
 
-				Expect(resolver.Resolve("test-id-2", "1.0")).To(Equal(libpak.BuildpackDependency{
+				Expect(resolver.Resolve("test-id-2", "1.0")).To(Equal(libpak.BuildModuleDependency{
 					ID:      "test-id-2",
 					Name:    "test-name",
 					Version: "1.0",
@@ -286,7 +286,7 @@ func testBuildpack(t *testing.T, context spec.G, it spec.S) {
 			})
 
 			it("filters by version constraint", func() {
-				resolver.Dependencies = []libpak.BuildpackDependency{
+				resolver.Dependencies = []libpak.BuildModuleDependency{
 					{
 						ID:      "test-id",
 						Name:    "test-name",
@@ -306,7 +306,7 @@ func testBuildpack(t *testing.T, context spec.G, it spec.S) {
 				}
 				resolver.StackID = "test-stack-1"
 
-				Expect(resolver.Resolve("test-id", "2.0")).To(Equal(libpak.BuildpackDependency{
+				Expect(resolver.Resolve("test-id", "2.0")).To(Equal(libpak.BuildModuleDependency{
 					ID:      "test-id",
 					Name:    "test-name",
 					Version: "2.0",
@@ -317,7 +317,7 @@ func testBuildpack(t *testing.T, context spec.G, it spec.S) {
 			})
 
 			it("filters by stack", func() {
-				resolver.Dependencies = []libpak.BuildpackDependency{
+				resolver.Dependencies = []libpak.BuildModuleDependency{
 					{
 						ID:      "test-id",
 						Name:    "test-name",
@@ -337,7 +337,7 @@ func testBuildpack(t *testing.T, context spec.G, it spec.S) {
 				}
 				resolver.StackID = "test-stack-3"
 
-				Expect(resolver.Resolve("test-id", "1.0")).To(Equal(libpak.BuildpackDependency{
+				Expect(resolver.Resolve("test-id", "1.0")).To(Equal(libpak.BuildModuleDependency{
 					ID:      "test-id",
 					Name:    "test-name",
 					Version: "1.0",
@@ -348,7 +348,7 @@ func testBuildpack(t *testing.T, context spec.G, it spec.S) {
 			})
 
 			it("filters by stack and supports the wildcard stack", func() {
-				resolver.Dependencies = []libpak.BuildpackDependency{
+				resolver.Dependencies = []libpak.BuildModuleDependency{
 					{
 						ID:      "test-id",
 						Name:    "test-name",
@@ -368,7 +368,7 @@ func testBuildpack(t *testing.T, context spec.G, it spec.S) {
 				}
 				resolver.StackID = "test-stack-3"
 
-				Expect(resolver.Resolve("test-id", "1.0")).To(Equal(libpak.BuildpackDependency{
+				Expect(resolver.Resolve("test-id", "1.0")).To(Equal(libpak.BuildModuleDependency{
 					ID:      "test-id",
 					Name:    "test-name",
 					Version: "1.0",
@@ -379,7 +379,7 @@ func testBuildpack(t *testing.T, context spec.G, it spec.S) {
 			})
 
 			it("filters by stack and treats no stacks as the wildcard stack", func() {
-				resolver.Dependencies = []libpak.BuildpackDependency{
+				resolver.Dependencies = []libpak.BuildModuleDependency{
 					{
 						ID:      "test-id",
 						Name:    "test-name",
@@ -399,7 +399,7 @@ func testBuildpack(t *testing.T, context spec.G, it spec.S) {
 				}
 				resolver.StackID = "test-stack-3"
 
-				Expect(resolver.Resolve("test-id", "1.0")).To(Equal(libpak.BuildpackDependency{
+				Expect(resolver.Resolve("test-id", "1.0")).To(Equal(libpak.BuildModuleDependency{
 					ID:      "test-id",
 					Name:    "test-name",
 					Version: "1.0",
@@ -410,7 +410,7 @@ func testBuildpack(t *testing.T, context spec.G, it spec.S) {
 			})
 
 			it("returns the best dependency", func() {
-				resolver.Dependencies = []libpak.BuildpackDependency{
+				resolver.Dependencies = []libpak.BuildModuleDependency{
 					{
 						ID:      "test-id",
 						Name:    "test-name",
@@ -430,7 +430,7 @@ func testBuildpack(t *testing.T, context spec.G, it spec.S) {
 				}
 				resolver.StackID = "test-stack-1"
 
-				Expect(resolver.Resolve("test-id", "1.*")).To(Equal(libpak.BuildpackDependency{
+				Expect(resolver.Resolve("test-id", "1.*")).To(Equal(libpak.BuildModuleDependency{
 					ID:      "test-id",
 					Name:    "test-name",
 					Version: "1.1",
@@ -441,7 +441,7 @@ func testBuildpack(t *testing.T, context spec.G, it spec.S) {
 			})
 
 			it("returns the best dependency after filtering", func() {
-				resolver.Dependencies = []libpak.BuildpackDependency{
+				resolver.Dependencies = []libpak.BuildModuleDependency{
 					{
 						ID:      "test-id-1",
 						Name:    "test-name-1",
@@ -501,7 +501,7 @@ func testBuildpack(t *testing.T, context spec.G, it spec.S) {
 				}
 				resolver.StackID = "test-stack-2"
 
-				Expect(resolver.Resolve("test-id-2", "")).To(Equal(libpak.BuildpackDependency{
+				Expect(resolver.Resolve("test-id-2", "")).To(Equal(libpak.BuildModuleDependency{
 					ID:      "test-id-2",
 					Name:    "test-name-2",
 					Version: "1.9.0",
@@ -512,7 +512,7 @@ func testBuildpack(t *testing.T, context spec.G, it spec.S) {
 			})
 
 			it("returns error if there are no matching dependencies", func() {
-				resolver.Dependencies = []libpak.BuildpackDependency{
+				resolver.Dependencies = []libpak.BuildModuleDependency{
 					{
 						ID:      "test-id",
 						Name:    "test-name",
@@ -546,7 +546,7 @@ func testBuildpack(t *testing.T, context spec.G, it spec.S) {
 			})
 
 			it("substitutes all wildcard for unspecified version constraint", func() {
-				resolver.Dependencies = []libpak.BuildpackDependency{
+				resolver.Dependencies = []libpak.BuildModuleDependency{
 					{
 						ID:      "test-id",
 						Name:    "test-name",
@@ -558,7 +558,7 @@ func testBuildpack(t *testing.T, context spec.G, it spec.S) {
 				}
 				resolver.StackID = "test-stack-1"
 
-				Expect(resolver.Resolve("test-id", "")).To(Equal(libpak.BuildpackDependency{
+				Expect(resolver.Resolve("test-id", "")).To(Equal(libpak.BuildModuleDependency{
 					ID:      "test-id",
 					Name:    "test-name",
 					Version: "1.1",
@@ -574,7 +574,7 @@ func testBuildpack(t *testing.T, context spec.G, it spec.S) {
 				resolver.Logger = &logger
 				soonDeprecated := time.Now().UTC().Add(30 * 24 * time.Hour)
 				notSoSoonDeprecated := time.Now().UTC().Add(60 * 24 * time.Hour)
-				resolver.Dependencies = []libpak.BuildpackDependency{
+				resolver.Dependencies = []libpak.BuildModuleDependency{
 					{
 						ID:      "missing-deprecation-date",
 						Name:    "missing-deprecation-date",

--- a/buildmodule_test.go
+++ b/buildmodule_test.go
@@ -84,7 +84,7 @@ func testBuildpack(t *testing.T, context spec.G, it spec.S) {
 			PURL: "test-purl",
 		}
 
-		Expect(dependency.AsSyftArtifact()).To(Equal(sbom.SyftArtifact{
+		Expect(dependency.AsSyftArtifact("buildpack.toml")).To(Equal(sbom.SyftArtifact{
 			ID:        "46713835f08d90b7",
 			Name:      "test-name",
 			Version:   "1.1.1",
@@ -92,6 +92,37 @@ func testBuildpack(t *testing.T, context spec.G, it spec.S) {
 			FoundBy:   "libpak",
 			Licenses:  []string{"test-type"},
 			Locations: []sbom.SyftLocation{{Path: "buildpack.toml"}},
+			CPEs:      []string{"test-cpe1", "test-cpe2"},
+			PURL:      "test-purl",
+		}))
+	})
+
+	it("renders extension dependency as a SyftArtifact", func() {
+		dependency := libpak.BuildModuleDependency{
+			ID:      "test-id",
+			Name:    "test-name",
+			Version: "1.1.1",
+			URI:     "test-uri",
+			SHA256:  "test-sha256",
+			Stacks:  []string{"test-stack"},
+			Licenses: []libpak.BuildModuleDependencyLicense{
+				{
+					Type: "test-type",
+					URI:  "test-uri",
+				},
+			},
+			CPEs: []string{"test-cpe1", "test-cpe2"},
+			PURL: "test-purl",
+		}
+
+		Expect(dependency.AsSyftArtifact("extension.toml")).To(Equal(sbom.SyftArtifact{
+			ID:        "9a52b9f58469d126",
+			Name:      "test-name",
+			Version:   "1.1.1",
+			Type:      "UnknownPackage",
+			FoundBy:   "libpak",
+			Licenses:  []string{"test-type"},
+			Locations: []sbom.SyftLocation{{Path: "extension.toml"}},
 			CPEs:      []string{"test-cpe1", "test-cpe2"},
 			PURL:      "test-purl",
 		}))

--- a/carton/buildmodule_dependency.go
+++ b/carton/buildmodule_dependency.go
@@ -28,24 +28,24 @@ import (
 )
 
 const (
-	BuildpackDependencyPattern      = `(?m)([\s]*.*id[\s]+=[\s]+"%s"\n.*\n[\s]*version[\s]+=[\s]+")%s("\n[\s]*uri[\s]+=[\s]+").*("\n[\s]*sha256[\s]+=[\s]+").*(".*)`
-	BuildpackDependencySubstitution = "${1}%s${2}%s${3}%s${4}"
+	BuildModuleDependencyPattern      = `(?m)([\s]*.*id[\s]+=[\s]+"%s"\n.*\n[\s]*version[\s]+=[\s]+")%s("\n[\s]*uri[\s]+=[\s]+").*("\n[\s]*sha256[\s]+=[\s]+").*(".*)`
+	BuildModuleDependencySubstitution = "${1}%s${2}%s${3}%s${4}"
 )
 
-type BuildpackDependency struct {
-	BuildpackPath  string
-	ID             string
-	SHA256         string
-	URI            string
-	Version        string
-	VersionPattern string
-	CPE            string
-	CPEPattern     string
-	PURL           string
-	PURLPattern    string
+type BuildModuleDependency struct {
+	BuildModulePath string
+	ID              string
+	SHA256          string
+	URI             string
+	Version         string
+	VersionPattern  string
+	CPE             string
+	CPEPattern      string
+	PURL            string
+	PURLPattern     string
 }
 
-func (b BuildpackDependency) Update(options ...Option) {
+func (b BuildModuleDependency) Update(options ...Option) {
 	config := Config{
 		exitHandler: internal.NewExitHandler(),
 	}
@@ -80,9 +80,9 @@ func (b BuildpackDependency) Update(options ...Option) {
 		return
 	}
 
-	c, err := os.ReadFile(b.BuildpackPath)
+	c, err := os.ReadFile(b.BuildModulePath)
 	if err != nil {
-		config.exitHandler.Error(fmt.Errorf("unable to read %s\n%w", b.BuildpackPath, err))
+		config.exitHandler.Error(fmt.Errorf("unable to read %s\n%w", b.BuildModulePath, err))
 		return
 	}
 
@@ -99,7 +99,7 @@ func (b BuildpackDependency) Update(options ...Option) {
 
 	md := make(map[string]interface{})
 	if err := toml.Unmarshal(c, &md); err != nil {
-		config.exitHandler.Error(fmt.Errorf("unable to decode md%s\n%w", b.BuildpackPath, err))
+		config.exitHandler.Error(fmt.Errorf("unable to decode md%s\n%w", b.BuildModulePath, err))
 		return
 	}
 
@@ -180,14 +180,14 @@ func (b BuildpackDependency) Update(options ...Option) {
 
 	c, err = internal.Marshal(md)
 	if err != nil {
-		config.exitHandler.Error(fmt.Errorf("unable to encode md %s\n%w", b.BuildpackPath, err))
+		config.exitHandler.Error(fmt.Errorf("unable to encode md %s\n%w", b.BuildModulePath, err))
 		return
 	}
 
 	c = append(comments, c...)
 
-	if err := os.WriteFile(b.BuildpackPath, c, 0644); err != nil {
-		config.exitHandler.Error(fmt.Errorf("unable to write %s\n%w", b.BuildpackPath, err))
+	if err := os.WriteFile(b.BuildModulePath, c, 0644); err != nil {
+		config.exitHandler.Error(fmt.Errorf("unable to write %s\n%w", b.BuildModulePath, err))
 		return
 	}
 }

--- a/carton/buildmodule_dependency_test.go
+++ b/carton/buildmodule_dependency_test.go
@@ -69,13 +69,13 @@ sha256  = "test-sha256-1"
 stacks  = [ "test-stack" ]
 `), 0644)).To(Succeed())
 
-		d := carton.BuildpackDependency{
-			BuildpackPath:  path,
-			ID:             "test-id",
-			SHA256:         "test-sha256-2",
-			URI:            "test-uri-2",
-			Version:        "test-version-2",
-			VersionPattern: `test-version-[\d]`,
+		d := carton.BuildModuleDependency{
+			BuildModulePath: path,
+			ID:              "test-id",
+			SHA256:          "test-sha256-2",
+			URI:             "test-uri-2",
+			Version:         "test-version-2",
+			VersionPattern:  `test-version-[\d]`,
 		}
 
 		d.Update(carton.WithExitHandler(exitHandler))
@@ -114,17 +114,17 @@ purl    = "pkg:generic/test-jre@different-version-1?arch=amd64"
 cpes    = ["cpe:2.3:a:test-vendor:test-product:test-version-1:patch1:*:*:*:*:*:*:*"]
 `), 0644)).To(Succeed())
 
-		d := carton.BuildpackDependency{
-			BuildpackPath:  path,
-			ID:             "test-id",
-			SHA256:         "test-sha256-2",
-			URI:            "test-uri-2",
-			Version:        "test-version-2",
-			VersionPattern: `test-version-[\d]`,
-			PURL:           "different-version-2",
-			PURLPattern:    `different-version-[\d]`,
-			CPE:            "test-version-2:patch2",
-			CPEPattern:     `test-version-[\d]:patch[\d]`,
+		d := carton.BuildModuleDependency{
+			BuildModulePath: path,
+			ID:              "test-id",
+			SHA256:          "test-sha256-2",
+			URI:             "test-uri-2",
+			Version:         "test-version-2",
+			VersionPattern:  `test-version-[\d]`,
+			PURL:            "different-version-2",
+			PURLPattern:     `different-version-[\d]`,
+			CPE:             "test-version-2:patch2",
+			CPEPattern:      `test-version-[\d]:patch[\d]`,
 		}
 
 		d.Update(carton.WithExitHandler(exitHandler))
@@ -175,17 +175,17 @@ purl    = "pkg:generic/test-jre@different-version-2?arch=amd64"
 cpes    = ["cpe:2.3:a:test-vendor:test-product:test-version-2:patch2:*:*:*:*:*:*:*"]
 `), 0644)).To(Succeed())
 
-		d := carton.BuildpackDependency{
-			BuildpackPath:  path,
-			ID:             "test-id",
-			SHA256:         "test-sha256-3",
-			URI:            "test-uri-3",
-			Version:        "test-version-3",
-			VersionPattern: `test-version-1`,
-			PURL:           "different-version-3",
-			PURLPattern:    `different-version-[\d]`,
-			CPE:            "test-version-3:patch3",
-			CPEPattern:     `test-version-[\d]:patch[\d]`,
+		d := carton.BuildModuleDependency{
+			BuildModulePath: path,
+			ID:              "test-id",
+			SHA256:          "test-sha256-3",
+			URI:             "test-uri-3",
+			Version:         "test-version-3",
+			VersionPattern:  `test-version-1`,
+			PURL:            "different-version-3",
+			PURLPattern:     `different-version-[\d]`,
+			CPE:             "test-version-3:patch3",
+			CPEPattern:      `test-version-[\d]:patch[\d]`,
 		}
 
 		d.Update(carton.WithExitHandler(exitHandler))
@@ -235,17 +235,17 @@ stacks  = [ "test-stack" ]
 cpes    = ["cpe:2.3:a:test-vendor:test-product:test-version-1:patch1:*:*:*:*:*:*:*"]
 `), 0644)).To(Succeed())
 
-		d := carton.BuildpackDependency{
-			BuildpackPath:  path,
-			ID:             "test-id",
-			SHA256:         "test-sha256-2",
-			URI:            "test-uri-2",
-			Version:        "test-version-2",
-			VersionPattern: `test-version-[\d]`,
-			PURL:           "different-version-2",
-			PURLPattern:    `different-version-[\d]`,
-			CPE:            "test-version-2:patch2",
-			CPEPattern:     `test-version-[\d]:patch[\d]`,
+		d := carton.BuildModuleDependency{
+			BuildModulePath: path,
+			ID:              "test-id",
+			SHA256:          "test-sha256-2",
+			URI:             "test-uri-2",
+			Version:         "test-version-2",
+			VersionPattern:  `test-version-[\d]`,
+			PURL:            "different-version-2",
+			PURLPattern:     `different-version-[\d]`,
+			CPE:             "test-version-2:patch2",
+			CPEPattern:      `test-version-[\d]:patch[\d]`,
 		}
 
 		d.Update(carton.WithExitHandler(exitHandler))
@@ -285,17 +285,17 @@ purl    = 1234
 cpes    = ["cpe:2.3:a:test-vendor:test-product:test-version-1:patch1:*:*:*:*:*:*:*"]
 `), 0644)).To(Succeed())
 
-		d := carton.BuildpackDependency{
-			BuildpackPath:  path,
-			ID:             "test-id",
-			SHA256:         "test-sha256-2",
-			URI:            "test-uri-2",
-			Version:        "test-version-2",
-			VersionPattern: `test-version-[\d]`,
-			PURL:           "different-version-2",
-			PURLPattern:    `different-version-[\d]`,
-			CPE:            "test-version-2:patch2",
-			CPEPattern:     `test-version-[\d]:patch[\d]`,
+		d := carton.BuildModuleDependency{
+			BuildModulePath: path,
+			ID:              "test-id",
+			SHA256:          "test-sha256-2",
+			URI:             "test-uri-2",
+			Version:         "test-version-2",
+			VersionPattern:  `test-version-[\d]`,
+			PURL:            "different-version-2",
+			PURLPattern:     `different-version-[\d]`,
+			CPE:             "test-version-2:patch2",
+			CPEPattern:      `test-version-[\d]:patch[\d]`,
 		}
 
 		d.Update(carton.WithExitHandler(exitHandler))
@@ -336,17 +336,17 @@ purl    = "pkg:generic/test-jre@different-version-1?arch=amd64"
 cpes    = 1234
 `), 0644)).To(Succeed())
 
-		d := carton.BuildpackDependency{
-			BuildpackPath:  path,
-			ID:             "test-id",
-			SHA256:         "test-sha256-2",
-			URI:            "test-uri-2",
-			Version:        "test-version-2",
-			VersionPattern: `test-version-[\d]`,
-			PURL:           "different-version-2",
-			PURLPattern:    `different-version-[\d]`,
-			CPE:            "test-version-2:patch2",
-			CPEPattern:     `test-version-[\d]:patch[\d]`,
+		d := carton.BuildModuleDependency{
+			BuildModulePath: path,
+			ID:              "test-id",
+			SHA256:          "test-sha256-2",
+			URI:             "test-uri-2",
+			Version:         "test-version-2",
+			VersionPattern:  `test-version-[\d]`,
+			PURL:            "different-version-2",
+			PURLPattern:     `different-version-[\d]`,
+			CPE:             "test-version-2:patch2",
+			CPEPattern:      `test-version-[\d]:patch[\d]`,
 		}
 
 		d.Update(carton.WithExitHandler(exitHandler))
@@ -389,13 +389,13 @@ version = "1.2.3"
   stacks  = [ "test-stack" ]
 `), 0644)).To(Succeed())
 
-		d := carton.BuildpackDependency{
-			BuildpackPath:  path,
-			ID:             "test-id",
-			SHA256:         "test-sha256-2",
-			URI:            "test-uri-2",
-			Version:        "test-version-2",
-			VersionPattern: `test-version-[\d]`,
+		d := carton.BuildModuleDependency{
+			BuildModulePath: path,
+			ID:              "test-id",
+			SHA256:          "test-sha256-2",
+			URI:             "test-uri-2",
+			Version:         "test-version-2",
+			VersionPattern:  `test-version-[\d]`,
 		}
 
 		d.Update(carton.WithExitHandler(exitHandler))

--- a/carton/package.go
+++ b/carton/package.go
@@ -127,7 +127,7 @@ func (p Package) Create(options ...Option) {
 		return
 	}
 
-	metadata, err := libpak.NewBuildpackMetadata(metadataMap)
+	metadata, err := libpak.NewBuildModuleMetadata(metadataMap)
 	if err != nil {
 		config.exitHandler.Error(fmt.Errorf("unable to decode metadata %s\n%w", metadataMap, err))
 		return
@@ -258,7 +258,7 @@ func (p Package) Create(options ...Option) {
 
 // matchDependency checks all filters against dependency and returns true if there is a match (or no filters) and false if there is no match
 // There is a match if a regular expression matches against the ID or Version
-func (p Package) matchDependency(dep libpak.BuildpackDependency) bool {
+func (p Package) matchDependency(dep libpak.BuildModuleDependency) bool {
 	if len(p.DependencyFilters) == 0 {
 		return true
 	}

--- a/carton/package_dependency.go
+++ b/carton/package_dependency.go
@@ -59,6 +59,7 @@ func (p PackageDependency) Update(options ...Option) {
 		}
 	}
 
+	// Do we have a buildpack.toml with an order element? (composite buildpack)
 	if p.BuildpackPath != "" {
 		if err := updateFile(p.BuildpackPath, func(md map[string]interface{}) {
 			parts := strings.Split(p.ID, "/")

--- a/cmd/create-package/main.go
+++ b/cmd/create-package/main.go
@@ -36,7 +36,7 @@ func main() {
 	flagSet.StringSliceVar(&p.DependencyFilters, "dependency-filter", []string{}, "one or more filters that are applied to exclude dependencies")
 	flagSet.BoolVar(&p.StrictDependencyFilters, "strict-filters", false, "require filter to match all data or just some data (default: false)")
 	flagSet.StringVar(&p.Source, "source", defaultSource(), "path to build package source directory (default: $PWD)")
-	flagSet.StringVar(&p.Version, "version", "", "version to substitute into buildpack.toml")
+	flagSet.StringVar(&p.Version, "version", "", "version to substitute into buildpack.toml/extension.toml")
 
 	if err := flagSet.Parse(os.Args[1:]); err != nil {
 		log.Fatal(fmt.Errorf("unable to parse flags\n%w", err))

--- a/cmd/update-buildmodule-dependency/main.go
+++ b/cmd/update-buildmodule-dependency/main.go
@@ -27,10 +27,10 @@ import (
 )
 
 func main() {
-	b := carton.BuildpackDependency{}
+	b := carton.BuildModuleDependency{}
 
-	flagSet := pflag.NewFlagSet("Update Buildpack Dependency", pflag.ExitOnError)
-	flagSet.StringVar(&b.BuildpackPath, "buildpack-toml", "", "path to buildpack.toml")
+	flagSet := pflag.NewFlagSet("Update Build Module Dependency", pflag.ExitOnError)
+	flagSet.StringVar(&b.BuildModulePath, "buildmodule-toml", "", "path to buildpack.toml or extension.toml")
 	flagSet.StringVar(&b.ID, "id", "", "the id of the dependency")
 	flagSet.StringVar(&b.SHA256, "sha256", "", "the new sha256 of the dependency")
 	flagSet.StringVar(&b.URI, "uri", "", "the new uri of the dependency")
@@ -45,8 +45,8 @@ func main() {
 		log.Fatal(fmt.Errorf("unable to parse flags\n%w", err))
 	}
 
-	if b.BuildpackPath == "" {
-		log.Fatal("buildpack-toml must be set")
+	if b.BuildModulePath == "" {
+		log.Fatal("buildmodule toml path must be set")
 	}
 
 	if b.ID == "" {

--- a/dependency_cache.go
+++ b/dependency_cache.go
@@ -161,10 +161,10 @@ type RequestModifierFunc func(request *http.Request) (*http.Request, error)
 //
 // If the BuildpackDependency's SHA256 is not set, the download can never be verified to be up to date and will always
 // download, skipping all the caches.
-func (d *DependencyCache) Artifact(dependency BuildpackDependency, mods ...RequestModifierFunc) (*os.File, error) {
+func (d *DependencyCache) Artifact(dependency BuildModuleDependency, mods ...RequestModifierFunc) (*os.File, error) {
 
 	var (
-		actual   BuildpackDependency
+		actual   BuildModuleDependency
 		artifact string
 		file     string
 		uri      = dependency.URI

--- a/dependency_cache_test.go
+++ b/dependency_cache_test.go
@@ -153,7 +153,7 @@ func testDependencyCache(t *testing.T, context spec.G, it spec.S) {
 		var (
 			cachePath       string
 			downloadPath    string
-			dependency      libpak.BuildpackDependency
+			dependency      libpak.BuildModuleDependency
 			dependencyCache libpak.DependencyCache
 			server          *ghttp.Server
 		)
@@ -170,7 +170,7 @@ func testDependencyCache(t *testing.T, context spec.G, it spec.S) {
 			RegisterTestingT(t)
 			server = ghttp.NewServer()
 
-			dependency = libpak.BuildpackDependency{
+			dependency = libpak.BuildModuleDependency{
 				ID:              "test-id",
 				Name:            "test-name",
 				Version:         "1.1.1",
@@ -178,7 +178,7 @@ func testDependencyCache(t *testing.T, context spec.G, it spec.S) {
 				SHA256:          "576dd8416de5619ea001d9662291d62444d1292a38e96956bc4651c01f14bca1",
 				Stacks:          []string{"test-stack"},
 				DeprecationDate: time.Now(),
-				Licenses: []libpak.BuildpackDependencyLicense{
+				Licenses: []libpak.BuildModuleDependencyLicense{
 					{
 						Type: "test-type",
 						URI:  "test-uri",

--- a/formatter.go
+++ b/formatter.go
@@ -21,7 +21,7 @@ import (
 )
 
 // DependenciesFormatter is the formatter for a []BuildpackDependency.
-type DependenciesFormatter []BuildpackDependency
+type DependenciesFormatter []BuildModuleDependency
 
 func (d DependenciesFormatter) String() string {
 	var s []string

--- a/formatter_test.go
+++ b/formatter_test.go
@@ -33,7 +33,7 @@ func testFormatter(t *testing.T, context spec.G, it spec.S) {
 	context("DependenciesFormatter", func() {
 
 		it("formats contents", func() {
-			deps := []libpak.BuildpackDependency{
+			deps := []libpak.BuildModuleDependency{
 				{
 					ID:      "test-id-1",
 					Version: "1.1.1",

--- a/layer.go
+++ b/layer.go
@@ -163,7 +163,7 @@ func (l *LayerContributor) reset(layer libcnb.Layer) error {
 type DependencyLayerContributor struct {
 
 	// Dependency is the dependency being contributed.
-	Dependency BuildpackDependency
+	Dependency BuildModuleDependency
 
 	// DependencyCache is the cache to use to get the dependency.
 	DependencyCache DependencyCache
@@ -182,7 +182,7 @@ type DependencyLayerContributor struct {
 }
 
 // NewDependencyLayerContributor returns a new DependencyLayerContributor for the given BuildpackDependency
-func NewDependencyLayerContributor(dependency BuildpackDependency, cache DependencyCache, types libcnb.LayerTypes) DependencyLayerContributor {
+func NewDependencyLayerContributor(dependency BuildModuleDependency, cache DependencyCache, types libcnb.LayerTypes) DependencyLayerContributor {
 	return DependencyLayerContributor{
 		Dependency:       dependency,
 		ExpectedMetadata: dependency,

--- a/layer.go
+++ b/layer.go
@@ -206,7 +206,8 @@ func (d *DependencyLayerContributor) Contribute(layer libcnb.Layer, f Dependency
 		}
 		defer artifact.Close()
 
-		sbomArtifact, err := d.Dependency.AsSyftArtifact()
+		// Only buildpacks can create layers, so source must be buildpack.toml
+		sbomArtifact, err := d.Dependency.AsSyftArtifact("buildpack.toml")
 		if err != nil {
 			return libcnb.Layer{}, fmt.Errorf("unable to get SBOM artifact %s\n%w", d.Dependency.ID, err)
 		}

--- a/layer_test.go
+++ b/layer_test.go
@@ -285,7 +285,7 @@ func testLayer(t *testing.T, context spec.G, it spec.S) {
 
 	context("DependencyLayerContributor", func() {
 		var (
-			dependency libpak.BuildpackDependency
+			dependency libpak.BuildModuleDependency
 			dlc        libpak.DependencyLayerContributor
 			server     *ghttp.Server
 		)
@@ -297,14 +297,14 @@ func testLayer(t *testing.T, context spec.G, it spec.S) {
 			deprecationDate, err := time.Parse(time.RFC3339, "2021-04-01T00:00:00Z")
 			Expect(err).ToNot(HaveOccurred())
 
-			dependency = libpak.BuildpackDependency{
+			dependency = libpak.BuildModuleDependency{
 				ID:      "test-id",
 				Name:    "test-name",
 				Version: "1.1.1",
 				URI:     fmt.Sprintf("%s/test-path", server.URL()),
 				SHA256:  "576dd8416de5619ea001d9662291d62444d1292a38e96956bc4651c01f14bca1",
 				Stacks:  []string{"test-stack"},
-				Licenses: []libpak.BuildpackDependencyLicense{
+				Licenses: []libpak.BuildModuleDependencyLicense{
 					{
 						Type: "test-type",
 						URI:  "test-uri",


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
Updates for libpak for Extension support. 

## Use Cases
<!-- An explanation of the use cases your change enables -->

Where appropriate, updates `buildpack` to be `buildmodule`, buildmodule represents either a buildpack or an extension
  - BuildpackConfiguration -> BuildModuleConfiguration
  - BuildpackDependency -> BuildModuleDependency
  - BuildpackDependencyLicense -> BuildModuleDependencyLicense
  
This allows for extensions to have dependencies and share common code with buildpacks for processing them. Metadata between extensions and buildpacks is common, and although it was possible to mostly process extension metadata without renaming the structs/code, it was rapidly becoming confusing as to which paths supported ONLY buildpacks, and which would support both buildpack and extension usage. This change helps to clarify that by having the common paths now be buildmodule rather than buildpack. (So now, if you see extensions calling into Buildpack stuff, you can expect issues!)

This flows out to the libpak commands that are offered via go, to alter their arg that passed the path to buildpack.toml to be a path to buildpack.toml OR extension.toml 

The command changes help pipeline-builder make sense when it's calling a command with an extension rather than a buildpack =)

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
