### PR TITLE
Only rely on shasum for dependency cache hit

### DIFF
--- a/dependency_cache_test.go
+++ b/dependency_cache_test.go
@@ -234,8 +234,30 @@ func testDependencyCache(t *testing.T, context spec.G, it spec.S) {
 			Expect(io.ReadAll(a)).To(Equal([]byte("test-fixture")))
 		})
 
+		it("returns from cache path even with updated metadata", func() {
+			copyFile(filepath.Join("testdata", "test-file"), filepath.Join(cachePath, dependency.SHA256, "test-path"))
+			dependency.DeprecationDate = time.Now()
+			writeTOML(filepath.Join(cachePath, fmt.Sprintf("%s.toml", dependency.SHA256)), dependency)
+
+			a, err := dependencyCache.Artifact(dependency)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(io.ReadAll(a)).To(Equal([]byte("test-fixture")))
+		})
+
 		it("returns from download path", func() {
 			copyFile(filepath.Join("testdata", "test-file"), filepath.Join(downloadPath, dependency.SHA256, "test-path"))
+			writeTOML(filepath.Join(downloadPath, fmt.Sprintf("%s.toml", dependency.SHA256)), dependency)
+
+			a, err := dependencyCache.Artifact(dependency)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(io.ReadAll(a)).To(Equal([]byte("test-fixture")))
+		})
+
+		it("returns from download path even with updated metadata", func() {
+			copyFile(filepath.Join("testdata", "test-file"), filepath.Join(downloadPath, dependency.SHA256, "test-path"))
+			dependency.DeprecationDate = time.Now()
 			writeTOML(filepath.Join(downloadPath, fmt.Sprintf("%s.toml", dependency.SHA256)), dependency)
 
 			a, err := dependencyCache.Artifact(dependency)


### PR DESCRIPTION
fixes #233, like proposed [here](https://github.com/paketo-buildpacks/libpak/pull/233#issuecomment-1528865966), let's do this change in the next major update. It is not breaking, but it will change the behaviour in a subtle way. Before, it was possible that the very same dependency was downloaded again.

<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
When checking if some dependency can be reused, it should be enough to check the `shasum`. There is no need to verify that the metadata is the same (the binary is).

## Use Cases
<!-- An explanation of the use cases your change enables -->
This caused cache misses when the metadata was different (e.g. `DeprecationDate`).

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
