### PR TITLE
Introduce struct with metadata to identify a dependency

### DIFF
--- a/buildpack.go
+++ b/buildpack.go
@@ -96,8 +96,8 @@ type BuildpackDependency struct {
 	DeprecationDate time.Time `toml:"deprecation_date"`
 }
 
-// BuildpackDependencyMetadata describes the dependency
-type BuildpackDependencyMetadata struct {
+// DependencyLayerContributorMetadata returns the subset of data from BuildpackDependency that is use as expected metadata for the DependencyLayerContributor.
+type DependencyLayerContributorMetadata struct {
 	// ID is the dependency ID.
 	ID string `toml:"id"`
 

--- a/buildpack.go
+++ b/buildpack.go
@@ -113,7 +113,7 @@ type DependencyLayerContributorMetadata struct {
 
 // GetMetadata return the relevant metadata of this dependency
 func (b BuildpackDependency) GetMetadata() DependencyLayerContributorMetadata {
-	return BuildpackDependencyMetadata{
+	return DependencyLayerContributorMetadata{
 		ID:      b.ID,
 		Name:    b.Name,
 		Version: b.Version,

--- a/buildpack.go
+++ b/buildpack.go
@@ -112,7 +112,7 @@ type DependencyLayerContributorMetadata struct {
 }
 
 // GetMetadata return the relevant metadata of this dependency
-func (b BuildpackDependency) GetMetadata() BuildpackDependencyMetadata {
+func (b BuildpackDependency) GetMetadata() DependencyLayerContributorMetadata {
 	return BuildpackDependencyMetadata{
 		ID:      b.ID,
 		Name:    b.Name,

--- a/buildpack.go
+++ b/buildpack.go
@@ -96,6 +96,31 @@ type BuildpackDependency struct {
 	DeprecationDate time.Time `toml:"deprecation_date"`
 }
 
+// BuildpackDependencyMetadata describes the dependency
+type BuildpackDependencyMetadata struct {
+	// ID is the dependency ID.
+	ID string `toml:"id"`
+
+	// Name is the dependency name.
+	Name string `toml:"name"`
+
+	// Version is the dependency version.
+	Version string `toml:"version"`
+
+	// SHA256 is the hash of the dependency.
+	SHA256 string `toml:"sha256"`
+}
+
+// GetMetadata return the relevant metadata of this dependency
+func (b BuildpackDependency) GetMetadata() BuildpackDependencyMetadata {
+	return BuildpackDependencyMetadata{
+		ID:      b.ID,
+		Name:    b.Name,
+		Version: b.Version,
+		SHA256:  b.SHA256,
+	}
+}
+
 // Equals compares the 2 structs if they are equal. This is very simiar to reflect.DeepEqual
 // except that properties that will not work (e.g. DeprecationDate) are ignored.
 func (b1 BuildpackDependency) Equals(b2 BuildpackDependency) bool {

--- a/layer.go
+++ b/layer.go
@@ -237,7 +237,7 @@ func NewDependencyLayer(dependency BuildpackDependency, cache DependencyCache, t
 func NewDependencyLayerContributor(dependency BuildpackDependency, cache DependencyCache, types libcnb.LayerTypes) DependencyLayerContributor {
 	return DependencyLayerContributor{
 		Dependency:       dependency,
-		ExpectedMetadata: dependency,
+		ExpectedMetadata: dependency.GetMetadata(),
 		DependencyCache:  cache,
 		ExpectedTypes:    types,
 	}


### PR DESCRIPTION
related to https://github.com/paketo-buildpacks/libpak/pull/233#issuecomment-1528865966

<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
This introduces a Metadata struct with all relevant properties to identify a dependency and still be descriptive.

## Use Cases
<!-- An explanation of the use cases your change enables -->
This allow users (e.g. `libjvm`) to use this metadata as layer metadata and not the whole dependency. That would
a) Simplify comparison if there is a cache hit (special logic for `deprecation_data`)
b) Ensure that no cache miss happens because some metadata changed (e.g. `url`)  

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
