### PR TITLE
adds logic to remove http query params from destination file name

### DIFF
--- a/dependency_cache.go
+++ b/dependency_cache.go
@@ -182,7 +182,19 @@ func (d *DependencyCache) Artifact(dependency BuildpackDependency, mods ...Reque
 			color.New(color.FgYellow, color.Bold).Sprint("Warning:"))
 
 		d.Logger.Bodyf("%s from %s", color.YellowString("Downloading"), uri)
-		artifact = filepath.Join(d.DownloadPath, filepath.Base(uri))
+
+		// ensure query parameters are not included in the downloaded file name if the uri is http type
+		downloadUri, err := url.Parse(uri)
+		if err != nil {
+			return nil, fmt.Errorf("unable to parse the download uri %s\n%w", uri, err)
+		}
+
+		if(downloadUri.Scheme == "http" || downloadUri.Scheme == "https") {
+			artifact = filepath.Join(d.DownloadPath, filepath.Base(downloadUri.Path))
+		} else {
+			artifact = filepath.Join(d.DownloadPath, filepath.Base(uri))
+		}
+
 		if err := d.download(uri, artifact, mods...); err != nil {
 			return nil, fmt.Errorf("unable to download %s\n%w", uri, err)
 		}

--- a/dependency_cache.go
+++ b/dependency_cache.go
@@ -190,7 +190,10 @@ func (d *DependencyCache) Artifact(dependency BuildpackDependency, mods ...Reque
 		}
 
 		if(downloadUri.Scheme == "http" || downloadUri.Scheme == "https") {
-			artifact = filepath.Join(d.DownloadPath, filepath.Base(downloadUri.Path))
+			hasher := sha256.New()
+			hasher.Write([]byte(uri))
+
+			artifact = filepath.Join(d.DownloadPath, hex.EncodeToString(hasher.Sum(nil)))
 		} else {
 			artifact = filepath.Join(d.DownloadPath, filepath.Base(uri))
 		}

--- a/dependency_cache_test.go
+++ b/dependency_cache_test.go
@@ -20,6 +20,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"hash"
 	"io"
 	"net/http"
 	"os"
@@ -157,6 +158,7 @@ func testDependencyCache(t *testing.T, context spec.G, it spec.S) {
 			downloadPath    string
 			dependency      libpak.BuildpackDependency
 			dependencyCache libpak.DependencyCache
+			hasher          hash.Hash
 			server          *ghttp.Server
 		)
 
@@ -165,6 +167,8 @@ func testDependencyCache(t *testing.T, context spec.G, it spec.S) {
 
 			cachePath = t.TempDir()
 			Expect(err).NotTo(HaveOccurred())
+
+			hasher = sha256.New()
 
 			downloadPath = t.TempDir()
 			Expect(err).NotTo(HaveOccurred())
@@ -319,12 +323,23 @@ func testDependencyCache(t *testing.T, context spec.G, it spec.S) {
 			Expect(io.ReadAll(a)).To(Equal([]byte("alternate-fixture")))
 		})
 
+		it("sets downloaded file name to uri's sha256", func() {
+			server.AppendHandlers(ghttp.RespondWith(http.StatusOK, "test-fixture"))
+
+			hasher.Write([]byte(dependency.URI))
+
+			a, err := dependencyCache.Artifact(dependency)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(io.ReadAll(a)).To(Equal([]byte("test-fixture")))
+			Expect(filepath.Base(a.Name())).To(Equal(hex.EncodeToString(hasher.Sum(nil))))
+		})
+
 		it("sets downloaded file name to uri's sha256 with empty SHA256 and query parameters in the uri", func() {
 			dependency.SHA256 = ""
 			dependency.URI = fmt.Sprintf("%s/test-path?param1=value1&param2=value2", server.URL())
 			server.AppendHandlers(ghttp.RespondWith(http.StatusOK, "alternate-fixture"))
 
-			hasher := sha256.New()
 			hasher.Write([]byte(dependency.URI))
 
 			a, err := dependencyCache.Artifact(dependency)

--- a/dependency_cache_test.go
+++ b/dependency_cache_test.go
@@ -17,6 +17,8 @@
 package libpak_test
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"net/http"
@@ -315,6 +317,21 @@ func testDependencyCache(t *testing.T, context spec.G, it spec.S) {
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(io.ReadAll(a)).To(Equal([]byte("alternate-fixture")))
+		})
+
+		it("sets downloaded file name to uri's sha256 with empty SHA256 and query parameters in the uri", func() {
+			dependency.SHA256 = ""
+			dependency.URI = fmt.Sprintf("%s/test-path?param1=value1&param2=value2", server.URL())
+			server.AppendHandlers(ghttp.RespondWith(http.StatusOK, "alternate-fixture"))
+
+			hasher := sha256.New()
+			hasher.Write([]byte(dependency.URI))
+
+			a, err := dependencyCache.Artifact(dependency)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(io.ReadAll(a)).To(Equal([]byte("alternate-fixture")))
+			Expect(filepath.Base(a.Name())).To(Equal(hex.EncodeToString(hasher.Sum(nil))))
 		})
 
 		it("sets User-Agent", func() {


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
This PR adds changes to ensure that downloaded **http** type dependency artifacts are given a filename that does not include the query parameters that might be present in the corresponding URI.
- parse the uri using net/url's Parse function 
- get the clean uri without the query parameters using the Path property
- use this clean uri to get the name for the downloaded artifact

## Use Cases
fixes #274 

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
