### PR TITLE
Default Logger to os.Stdout

### DIFF
--- a/layer.go
+++ b/layer.go
@@ -59,6 +59,7 @@ func NewLayerContributor(name string, expectedMetadata interface{}, expectedType
 		ExpectedMetadata: expectedMetadata,
 		Name:             name,
 		ExpectedTypes:    expectedTypes,
+		Logger:           bard.NewLogger(os.Stdout),
 	}
 }
 
@@ -119,7 +120,7 @@ func (l *LayerContributor) checkIfMetadataMatches(layer libcnb.Layer) (map[strin
 	l.Logger.Debugf("Expected metadata: %+v", expected)
 	l.Logger.Debugf("Actual metadata: %+v", layer.Metadata)
 
-	match, err := l.Equals(expected,layer.Metadata)
+	match, err := l.Equals(expected, layer.Metadata)
 	if err != nil {
 		return map[string]interface{}{}, false, fmt.Errorf("unable to compare metadata\n%w", err)
 	}
@@ -135,7 +136,7 @@ func (l *LayerContributor) Equals(expectedM map[string]interface{}, layerM map[s
 				break
 			}
 		}
-    }
+	}
 	if dep, ok := layerM["dependency"].(map[string]interface{}); ok {
 		for k, v := range dep {
 			if k == "deprecation_date" {
@@ -148,7 +149,7 @@ func (l *LayerContributor) Equals(expectedM map[string]interface{}, layerM map[s
 				break
 			}
 		}
-	} 
+	}
 	return reflect.DeepEqual(expectedM, layerM), nil
 }
 
@@ -240,6 +241,7 @@ func NewDependencyLayerContributor(dependency BuildpackDependency, cache Depende
 		ExpectedMetadata: dependency,
 		DependencyCache:  cache,
 		ExpectedTypes:    types,
+		Logger:           bard.NewLogger(os.Stdout),
 	}
 }
 
@@ -325,6 +327,7 @@ func NewHelperLayerContributor(buildpack libcnb.Buildpack, names ...string) Help
 		Path:          filepath.Join(buildpack.Path, "bin", "helper"),
 		Names:         names,
 		BuildpackInfo: buildpack.Info,
+		Logger:        bard.NewLogger(os.Stdout),
 	}
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->
fixes #46 

## Summary
<!-- A short explanation of the proposed change -->
Uses `Stdout` as default log target.

## Use Cases
<!-- An explanation of the use cases your change enables -->
By default, the `bard.Logger` is an empty object and does not log anything. Adding the logger to the factory function, is not really an option since it would be incompatible and need a major version bump. This change makes sure that the logs are at least written to `stdout` by default and since `Logger` is public, it can then be modified. 

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [X] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
