### PR TITLE
Introduce struct with metadata to identify a dependency

### DIFF
--- a/buildmodule.go
+++ b/buildmodule.go
@@ -95,6 +95,31 @@ type BuildModuleDependency struct {
 	DeprecationDate time.Time `toml:"deprecation_date"`
 }
 
+// DependencyLayerContributorMetadata returns the subset of data from BuildpackDependency that is use as expected metadata for the DependencyLayerContributor.
+type DependencyLayerContributorMetadata struct {
+	// ID is the dependency ID.
+	ID string `toml:"id"`
+
+	// Name is the dependency name.
+	Name string `toml:"name"`
+
+	// Version is the dependency version.
+	Version string `toml:"version"`
+
+	// SHA256 is the hash of the dependency.
+	SHA256 string `toml:"sha256"`
+}
+
+// GetMetadata return the relevant metadata of this dependency
+func (b BuildModuleDependency) GetMetadata() DependencyLayerContributorMetadata {
+	return DependencyLayerContributorMetadata{
+		ID:      b.ID,
+		Name:    b.Name,
+		Version: b.Version,
+		SHA256:  b.SHA256,
+	}
+}
+
 // Equals compares the 2 structs if they are equal. This is very simiar to reflect.DeepEqual
 // except that properties that will not work (e.g. DeprecationDate) are ignored.
 func (b1 BuildModuleDependency) Equals(b2 BuildModuleDependency) bool {

--- a/layer.go
+++ b/layer.go
@@ -224,7 +224,7 @@ func NewDependencyLayerContributor(dependency BuildModuleDependency, cache Depen
 	return DependencyLayerContributor{
 		Dependency:       dependency,
 		DependencyCache:  cache,
-		ExpectedMetadata: dependency,
+		ExpectedMetadata: dependency.GetMetadata(),
 		ExpectedTypes:    types,
 		Logger:           logger,
 	}


### PR DESCRIPTION
related to https://github.com/paketo-buildpacks/libpak/pull/233#issuecomment-1528865966
related to https://github.com/paketo-buildpacks/libpak/pull/267#discussion_r1284727496

<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
This introduces a Metadata struct with all relevant properties to identify a dependency and still be descriptive.

## Use Cases
<!-- An explanation of the use cases your change enables -->
This allow users (e.g. `libjvm`) to use this metadata as layer metadata and not the whole dependency. That would
a) Simplify comparison if there is a cache hit (special logic for `deprecation_data`)
b) Ensure that no cache miss happens because some metadata changed (e.g. `url`)  

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).