### PR TITLE
libpak API evolution

### DIFF
--- a/build.go
+++ b/build.go
@@ -19,8 +19,8 @@ package libpak
 import (
 	"github.com/buildpacks/libcnb/v2"
 
-	"github.com/paketo-buildpacks/libpak/v2/bard"
 	"github.com/paketo-buildpacks/libpak/v2/internal"
+	"github.com/paketo-buildpacks/libpak/v2/log"
 )
 
 // Build is called by the main function of a buildpack, for build.
@@ -40,7 +40,7 @@ type buildDelegate struct {
 func (b buildDelegate) Build(context libcnb.BuildContext) (libcnb.BuildResult, error) {
 	result, err := b.delegate(context)
 	if err != nil {
-		err = bard.IdentifiableError{
+		err = log.IdentifiableError{
 			Name:        context.Buildpack.Info.Name,
 			Description: context.Buildpack.Info.Version,
 			Err:         err,

--- a/build_test.go
+++ b/build_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/stretchr/testify/mock"
 
 	"github.com/paketo-buildpacks/libpak/v2"
-	"github.com/paketo-buildpacks/libpak/v2/bard"
+	"github.com/paketo-buildpacks/libpak/v2/log"
 )
 
 func testBuild(t *testing.T, context spec.G, it spec.S) {
@@ -132,7 +132,7 @@ version = "test-version"`),
 			libcnb.WithExitHandler(exitHandler),
 		)
 
-		Expect(exitHandler.Calls[0].Arguments.Get(0)).To(MatchError(bard.IdentifiableError{
+		Expect(exitHandler.Calls[0].Arguments.Get(0)).To(MatchError(log.IdentifiableError{
 			Name:        "test-name",
 			Description: "test-version",
 			Err:         fmt.Errorf("test-error"),

--- a/buildmodule.go
+++ b/buildmodule.go
@@ -28,7 +28,7 @@ import (
 	"github.com/Masterminds/semver/v3"
 	"github.com/heroku/color"
 
-	"github.com/paketo-buildpacks/libpak/v2/bard"
+	"github.com/paketo-buildpacks/libpak/v2/log"
 	"github.com/paketo-buildpacks/libpak/v2/sbom"
 )
 
@@ -321,7 +321,7 @@ func (c configurationEntry) String(nameLength int, valueLength int) string {
 
 // NewConfigurationResolver creates a new instance from buildmodule metadata.  Logs configuration options to the body
 // level int the form 'Set $Name to configure $Description[. Default <i>$Default</i>.]'.
-func NewConfigurationResolver(md BuildModuleMetadata, logger *bard.Logger) (ConfigurationResolver, error) {
+func NewConfigurationResolver(md BuildModuleMetadata, logger *log.Logger) (ConfigurationResolver, error) {
 
 	cr := ConfigurationResolver{Configurations: md.Configurations}
 
@@ -435,7 +435,7 @@ type DependencyResolver struct {
 	StackID string
 
 	// Logger is the logger used to write to the console.
-	Logger *bard.Logger
+	Logger *log.Logger
 }
 
 // NewDependencyResolver creates a new instance from the build module metadata and stack id.

--- a/buildmodule_test.go
+++ b/buildmodule_test.go
@@ -284,7 +284,6 @@ func testBuildpack(t *testing.T, context spec.G, it spec.S) {
 		)
 
 		context("Resolve", func() {
-
 			it("filters by id", func() {
 				resolver.Dependencies = []libpak.BuildModuleDependency{
 					{
@@ -601,8 +600,8 @@ func testBuildpack(t *testing.T, context spec.G, it spec.S) {
 
 			it("prints outdated dependencies", func() {
 				buff := bytes.NewBuffer(nil)
-				logger := log.NewLogger(buff)
-				resolver.Logger = &logger
+				logger := log.NewPaketoLogger(buff)
+				resolver.Logger = logger
 				soonDeprecated := time.Now().UTC().Add(30 * 24 * time.Hour)
 				notSoSoonDeprecated := time.Now().UTC().Add(60 * 24 * time.Hour)
 				resolver.Dependencies = []libpak.BuildModuleDependency{

--- a/buildmodule_test.go
+++ b/buildmodule_test.go
@@ -29,8 +29,8 @@ import (
 	"github.com/sclevine/spec"
 
 	"github.com/paketo-buildpacks/libpak/v2"
-	"github.com/paketo-buildpacks/libpak/v2/bard"
 	"github.com/paketo-buildpacks/libpak/v2/internal"
+	"github.com/paketo-buildpacks/libpak/v2/log"
 	"github.com/paketo-buildpacks/libpak/v2/sbom"
 )
 
@@ -601,7 +601,7 @@ func testBuildpack(t *testing.T, context spec.G, it spec.S) {
 
 			it("prints outdated dependencies", func() {
 				buff := bytes.NewBuffer(nil)
-				logger := bard.NewLogger(buff)
+				logger := log.NewLogger(buff)
 				resolver.Logger = &logger
 				soonDeprecated := time.Now().UTC().Add(30 * 24 * time.Hour)
 				notSoSoonDeprecated := time.Now().UTC().Add(60 * 24 * time.Hour)

--- a/carton/build_image_dependency.go
+++ b/carton/build_image_dependency.go
@@ -21,8 +21,8 @@ import (
 	"os"
 	"regexp"
 
-	"github.com/paketo-buildpacks/libpak/v2/bard"
 	"github.com/paketo-buildpacks/libpak/v2/internal"
+	"github.com/paketo-buildpacks/libpak/v2/log"
 )
 
 const (
@@ -44,8 +44,8 @@ func (i BuildImageDependency) Update(options ...Option) {
 		config = option(config)
 	}
 
-	logger := bard.NewLogger(os.Stdout)
-	_, _ = fmt.Fprintf(logger.TitleWriter(), "\n%s\n", bard.FormatIdentity("Build Image", i.Version))
+	logger := log.NewLogger(os.Stdout)
+	_, _ = fmt.Fprintf(logger.TitleWriter(), "\n%s\n", log.FormatIdentity("Build Image", i.Version))
 
 	c, err := os.ReadFile(i.BuilderPath)
 	if err != nil {

--- a/carton/build_image_dependency.go
+++ b/carton/build_image_dependency.go
@@ -44,7 +44,7 @@ func (i BuildImageDependency) Update(options ...Option) {
 		config = option(config)
 	}
 
-	logger := log.NewLogger(os.Stdout)
+	logger := log.NewPaketoLogger(os.Stdout)
 	_, _ = fmt.Fprintf(logger.TitleWriter(), "\n%s\n", log.FormatIdentity("Build Image", i.Version))
 
 	c, err := os.ReadFile(i.BuilderPath)

--- a/carton/buildmodule_dependency.go
+++ b/carton/buildmodule_dependency.go
@@ -23,8 +23,8 @@ import (
 	"regexp"
 
 	"github.com/BurntSushi/toml"
-	"github.com/paketo-buildpacks/libpak/v2/bard"
 	"github.com/paketo-buildpacks/libpak/v2/internal"
+	"github.com/paketo-buildpacks/libpak/v2/log"
 )
 
 const (
@@ -54,8 +54,8 @@ func (b BuildModuleDependency) Update(options ...Option) {
 		config = option(config)
 	}
 
-	logger := bard.NewLogger(os.Stdout)
-	_, _ = fmt.Fprintf(logger.TitleWriter(), "\n%s\n", bard.FormatIdentity(b.ID, b.VersionPattern))
+	logger := log.NewLogger(os.Stdout)
+	_, _ = fmt.Fprintf(logger.TitleWriter(), "\n%s\n", log.FormatIdentity(b.ID, b.VersionPattern))
 	logger.Headerf("Version: %s", b.Version)
 	logger.Headerf("PURL:    %s", b.PURL)
 	logger.Headerf("CPEs:    %s", b.CPE)

--- a/carton/buildmodule_dependency.go
+++ b/carton/buildmodule_dependency.go
@@ -54,7 +54,7 @@ func (b BuildModuleDependency) Update(options ...Option) {
 		config = option(config)
 	}
 
-	logger := log.NewLogger(os.Stdout)
+	logger := log.NewPaketoLogger(os.Stdout)
 	_, _ = fmt.Fprintf(logger.TitleWriter(), "\n%s\n", log.FormatIdentity(b.ID, b.VersionPattern))
 	logger.Headerf("Version: %s", b.Version)
 	logger.Headerf("PURL:    %s", b.PURL)

--- a/carton/lifecycle_dependency.go
+++ b/carton/lifecycle_dependency.go
@@ -44,7 +44,7 @@ func (l LifecycleDependency) Update(options ...Option) {
 		config = option(config)
 	}
 
-	logger := log.NewLogger(os.Stdout)
+	logger := log.NewPaketoLogger(os.Stdout)
 	_, _ = fmt.Fprintf(logger.TitleWriter(), "\n%s\n", log.FormatIdentity("Lifecycle", l.Version))
 
 	c, err := os.ReadFile(l.BuilderPath)

--- a/carton/lifecycle_dependency.go
+++ b/carton/lifecycle_dependency.go
@@ -21,8 +21,8 @@ import (
 	"os"
 	"regexp"
 
-	"github.com/paketo-buildpacks/libpak/v2/bard"
 	"github.com/paketo-buildpacks/libpak/v2/internal"
+	"github.com/paketo-buildpacks/libpak/v2/log"
 )
 
 const (
@@ -44,8 +44,8 @@ func (l LifecycleDependency) Update(options ...Option) {
 		config = option(config)
 	}
 
-	logger := bard.NewLogger(os.Stdout)
-	_, _ = fmt.Fprintf(logger.TitleWriter(), "\n%s\n", bard.FormatIdentity("Lifecycle", l.Version))
+	logger := log.NewLogger(os.Stdout)
+	_, _ = fmt.Fprintf(logger.TitleWriter(), "\n%s\n", log.FormatIdentity("Lifecycle", l.Version))
 
 	c, err := os.ReadFile(l.BuilderPath)
 	if err != nil {

--- a/carton/package.go
+++ b/carton/package.go
@@ -29,9 +29,9 @@ import (
 	"github.com/heroku/color"
 
 	"github.com/paketo-buildpacks/libpak/v2"
-	"github.com/paketo-buildpacks/libpak/v2/bard"
 	"github.com/paketo-buildpacks/libpak/v2/effect"
 	"github.com/paketo-buildpacks/libpak/v2/internal"
+	"github.com/paketo-buildpacks/libpak/v2/log"
 )
 
 // Package is an object that contains the configuration for building a package.
@@ -76,7 +76,7 @@ func (p Package) Create(options ...Option) {
 		file string
 	)
 
-	logger := bard.NewLogger(os.Stdout)
+	logger := log.NewLogger(os.Stdout)
 
 	// Is this a buildpack or an extension?
 	bpfile := filepath.Join(p.Source, "buildpack.toml")

--- a/carton/package.go
+++ b/carton/package.go
@@ -76,7 +76,7 @@ func (p Package) Create(options ...Option) {
 		file string
 	)
 
-	logger := log.NewLogger(os.Stdout)
+	logger := log.NewPaketoLogger(os.Stdout)
 
 	// Is this a buildpack or an extension?
 	bpfile := filepath.Join(p.Source, "buildpack.toml")
@@ -103,7 +103,7 @@ func (p Package) Create(options ...Option) {
 		name = b.Info.Name
 		version = b.Info.Version
 		homepage = b.Info.Homepage
-		logger.Debug("Buildpack: %+v", b)
+		logger.Debugf("Buildpack: %+v", b)
 	} else if _, err := os.Stat(extnfile); err == nil {
 		s, err := os.ReadFile(extnfile)
 		if err != nil {
@@ -121,7 +121,7 @@ func (p Package) Create(options ...Option) {
 		version = e.Info.Version
 		homepage = e.Info.Homepage
 		extension = true
-		logger.Debug("Extension: %+v", e)
+		logger.Debugf("Extension: %+v", e)
 	} else {
 		config.exitHandler.Error(fmt.Errorf("unable to read buildpack/extension.toml at %s", p.Source))
 		return
@@ -138,7 +138,7 @@ func (p Package) Create(options ...Option) {
 	for _, i := range metadata.IncludeFiles {
 		entries[i] = filepath.Join(p.Source, i)
 	}
-	logger.Debug("Include files: %+v", entries)
+	logger.Debugf("Include files: %+v", entries)
 
 	if p.Version != "" {
 		version = p.Version

--- a/carton/package_dependency.go
+++ b/carton/package_dependency.go
@@ -44,7 +44,7 @@ func (p PackageDependency) Update(options ...Option) {
 		config = option(config)
 	}
 
-	logger := log.NewLogger(os.Stdout)
+	logger := log.NewPaketoLogger(os.Stdout)
 	_, _ = fmt.Fprintf(logger.TitleWriter(), "\n%s\n", log.FormatIdentity(p.ID, p.Version))
 
 	if p.BuilderPath != "" {

--- a/carton/package_dependency.go
+++ b/carton/package_dependency.go
@@ -23,8 +23,8 @@ import (
 	"strings"
 
 	"github.com/BurntSushi/toml"
-	"github.com/paketo-buildpacks/libpak/v2/bard"
 	"github.com/paketo-buildpacks/libpak/v2/internal"
+	"github.com/paketo-buildpacks/libpak/v2/log"
 )
 
 type PackageDependency struct {
@@ -44,8 +44,8 @@ func (p PackageDependency) Update(options ...Option) {
 		config = option(config)
 	}
 
-	logger := bard.NewLogger(os.Stdout)
-	_, _ = fmt.Fprintf(logger.TitleWriter(), "\n%s\n", bard.FormatIdentity(p.ID, p.Version))
+	logger := log.NewLogger(os.Stdout)
+	_, _ = fmt.Fprintf(logger.TitleWriter(), "\n%s\n", log.FormatIdentity(p.ID, p.Version))
 
 	if p.BuilderPath != "" {
 		if err := updateFile(p.BuilderPath, updateByKey("buildpacks", p.ID, p.Version)); err != nil {

--- a/dependency_cache.go
+++ b/dependency_cache.go
@@ -49,7 +49,6 @@ type HttpClientTimeouts struct {
 // DependencyCache allows a user to get an artifact either from a buildmodule's cache, a previous download, or to download
 // directly.
 type DependencyCache struct {
-
 	// CachePath is the location where the buildmodule has cached its dependencies.
 	CachePath string
 
@@ -71,12 +70,13 @@ type DependencyCache struct {
 
 // NewDependencyCache creates a new instance setting the default cache path (<BUILDMODULE_PATH>/dependencies) and user
 // agent (<BUILDMODULE_ID>/<BUILDMODULE_VERSION>).
-func NewDependencyCache(buildModuleID string, buildModuleVersion string, buildModulePath string, platformBindings libcnb.Bindings) (DependencyCache, error) {
+func NewDependencyCache(buildModuleID string, buildModuleVersion string, buildModulePath string, platformBindings libcnb.Bindings, logger log.Logger) (DependencyCache, error) {
 	cache := DependencyCache{
 		CachePath:    filepath.Join(buildModulePath, "dependencies"),
 		DownloadPath: os.TempDir(),
-		UserAgent:    fmt.Sprintf("%s/%s", buildModuleID, buildModuleVersion),
+		Logger:       logger,
 		Mappings:     map[string]string{},
+		UserAgent:    fmt.Sprintf("%s/%s", buildModuleID, buildModuleVersion),
 	}
 	mappings, err := mappingsFromBindings(platformBindings)
 	if err != nil {
@@ -161,7 +161,6 @@ type RequestModifierFunc func(request *http.Request) (*http.Request, error)
 // If the BuildpackDependency's SHA256 is not set, the download can never be verified to be up to date and will always
 // download, skipping all the caches.
 func (d *DependencyCache) Artifact(dependency BuildModuleDependency, mods ...RequestModifierFunc) (*os.File, error) {
-
 	var (
 		artifact string
 		file     string

--- a/dependency_cache.go
+++ b/dependency_cache.go
@@ -34,7 +34,7 @@ import (
 	"github.com/buildpacks/libcnb/v2"
 	"github.com/heroku/color"
 
-	"github.com/paketo-buildpacks/libpak/v2/bard"
+	"github.com/paketo-buildpacks/libpak/v2/log"
 	"github.com/paketo-buildpacks/libpak/v2/sherpa"
 )
 
@@ -57,7 +57,7 @@ type DependencyCache struct {
 	DownloadPath string
 
 	// Logger is the logger used to write to the console.
-	Logger bard.Logger
+	Logger log.Logger
 
 	// UserAgent is the User-Agent string to use with requests.
 	UserAgent string

--- a/dependency_cache_test.go
+++ b/dependency_cache_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/sclevine/spec"
 
 	"github.com/paketo-buildpacks/libpak/v2"
+	"github.com/paketo-buildpacks/libpak/v2/log"
 )
 
 func testDependencyCache(t *testing.T, context spec.G, it spec.S) {
@@ -55,7 +56,7 @@ func testDependencyCache(t *testing.T, context spec.G, it spec.S) {
 		})
 
 		it("set default CachePath and UserAgent", func() {
-			dependencyCache, err := libpak.NewDependencyCache(ctx.Buildpack.Info.ID, ctx.Buildpack.Info.Version, ctx.Buildpack.Path, ctx.Platform.Bindings)
+			dependencyCache, err := libpak.NewDependencyCache(ctx.Buildpack.Info.ID, ctx.Buildpack.Info.Version, ctx.Buildpack.Path, ctx.Platform.Bindings, log.NewDiscardLogger())
 			Expect(err).NotTo(HaveOccurred())
 			Expect(dependencyCache.CachePath).To(Equal(filepath.Join("some/path/dependencies")))
 			Expect(dependencyCache.UserAgent).To(Equal("some-buildpack-id/some-buildpack-version"))
@@ -63,7 +64,7 @@ func testDependencyCache(t *testing.T, context spec.G, it spec.S) {
 		})
 
 		it("uses default timeout values", func() {
-			dependencyCache, err := libpak.NewDependencyCache(ctx.Buildpack.Info.ID, ctx.Buildpack.Info.Version, ctx.Buildpack.Path, ctx.Platform.Bindings)
+			dependencyCache, err := libpak.NewDependencyCache(ctx.Buildpack.Info.ID, ctx.Buildpack.Info.Version, ctx.Buildpack.Path, ctx.Platform.Bindings, log.NewDiscardLogger())
 			Expect(err).NotTo(HaveOccurred())
 			Expect(dependencyCache.HttpClientTimeouts.DialerTimeout).To(Equal(6 * time.Second))
 			Expect(dependencyCache.HttpClientTimeouts.DialerKeepAlive).To(Equal(60 * time.Second))
@@ -82,7 +83,7 @@ func testDependencyCache(t *testing.T, context spec.G, it spec.S) {
 			})
 
 			it("uses custom timeout values", func() {
-				dependencyCache, err := libpak.NewDependencyCache(ctx.Buildpack.Info.ID, ctx.Buildpack.Info.Version, ctx.Buildpack.Path, ctx.Platform.Bindings)
+				dependencyCache, err := libpak.NewDependencyCache(ctx.Buildpack.Info.ID, ctx.Buildpack.Info.Version, ctx.Buildpack.Path, ctx.Platform.Bindings, log.NewDiscardLogger())
 				Expect(err).NotTo(HaveOccurred())
 				Expect(dependencyCache.HttpClientTimeouts.DialerTimeout).To(Equal(7 * time.Second))
 				Expect(dependencyCache.HttpClientTimeouts.DialerKeepAlive).To(Equal(50 * time.Second))
@@ -119,7 +120,7 @@ func testDependencyCache(t *testing.T, context spec.G, it spec.S) {
 			})
 
 			it("sets Mappings", func() {
-				dependencyCache, err := libpak.NewDependencyCache(ctx.Buildpack.Info.ID, ctx.Buildpack.Info.Version, ctx.Buildpack.Path, ctx.Platform.Bindings)
+				dependencyCache, err := libpak.NewDependencyCache(ctx.Buildpack.Info.ID, ctx.Buildpack.Info.Version, ctx.Buildpack.Path, ctx.Platform.Bindings, log.NewDiscardLogger())
 				Expect(err).NotTo(HaveOccurred())
 				Expect(dependencyCache.Mappings).To(Equal(
 					map[string]string{
@@ -142,7 +143,7 @@ func testDependencyCache(t *testing.T, context spec.G, it spec.S) {
 				})
 
 				it("errors", func() {
-					_, err := libpak.NewDependencyCache(ctx.Buildpack.Info.ID, ctx.Buildpack.Info.Version, ctx.Buildpack.Path, ctx.Platform.Bindings)
+					_, err := libpak.NewDependencyCache(ctx.Buildpack.Info.ID, ctx.Buildpack.Info.Version, ctx.Buildpack.Path, ctx.Platform.Bindings, log.NewDiscardLogger())
 					Expect(err).To(HaveOccurred())
 				})
 			})
@@ -191,6 +192,7 @@ func testDependencyCache(t *testing.T, context spec.G, it spec.S) {
 			dependencyCache = libpak.DependencyCache{
 				CachePath:    cachePath,
 				DownloadPath: downloadPath,
+				Logger:       log.NewDiscardLogger(),
 				UserAgent:    "test-user-agent",
 			}
 		})

--- a/detect.go
+++ b/detect.go
@@ -19,8 +19,8 @@ package libpak
 import (
 	"github.com/buildpacks/libcnb/v2"
 
-	"github.com/paketo-buildpacks/libpak/v2/bard"
 	"github.com/paketo-buildpacks/libpak/v2/internal"
+	"github.com/paketo-buildpacks/libpak/v2/log"
 )
 
 // Detect is called by the main function of a buildpack, for detection.
@@ -39,7 +39,7 @@ type detectDelegate struct {
 func (d detectDelegate) Detect(context libcnb.DetectContext) (libcnb.DetectResult, error) {
 	result, err := d.delegate(context)
 	if err != nil {
-		err = bard.IdentifiableError{
+		err = log.IdentifiableError{
 			Name:        context.Buildpack.Info.Name,
 			Description: context.Buildpack.Info.Version,
 			Err:         err,

--- a/detect_test.go
+++ b/detect_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/stretchr/testify/mock"
 
 	"github.com/paketo-buildpacks/libpak/v2"
-	"github.com/paketo-buildpacks/libpak/v2/bard"
+	"github.com/paketo-buildpacks/libpak/v2/log"
 )
 
 func testDetect(t *testing.T, context spec.G, it spec.S) {
@@ -131,7 +131,7 @@ version = "test-version"`),
 			libcnb.WithExitHandler(exitHandler),
 		)
 
-		Expect(exitHandler.Calls[0].Arguments.Get(0)).To(MatchError(bard.IdentifiableError{
+		Expect(exitHandler.Calls[0].Arguments.Get(0)).To(MatchError(log.IdentifiableError{
 			Name:        "test-name",
 			Description: "test-version",
 			Err:         fmt.Errorf("test-error"),

--- a/generate.go
+++ b/generate.go
@@ -19,8 +19,8 @@ package libpak
 import (
 	"github.com/buildpacks/libcnb/v2"
 
-	"github.com/paketo-buildpacks/libpak/v2/bard"
 	"github.com/paketo-buildpacks/libpak/v2/internal"
+	"github.com/paketo-buildpacks/libpak/v2/log"
 )
 
 // Generate is called by the main function of an extension, for generation.
@@ -40,7 +40,7 @@ type generateDelegate struct {
 func (b generateDelegate) Generate(context libcnb.GenerateContext) (libcnb.GenerateResult, error) {
 	result, err := b.delegate(context)
 	if err != nil {
-		err = bard.IdentifiableError{
+		err = log.IdentifiableError{
 			Name:        context.Extension.Info.Name,
 			Description: context.Extension.Info.Version,
 			Err:         err,

--- a/generate_test.go
+++ b/generate_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/stretchr/testify/mock"
 
 	"github.com/paketo-buildpacks/libpak/v2"
-	"github.com/paketo-buildpacks/libpak/v2/bard"
+	"github.com/paketo-buildpacks/libpak/v2/log"
 )
 
 func testGenerate(t *testing.T, context spec.G, it spec.S) {
@@ -128,7 +128,7 @@ version = "test-version"`),
 			libcnb.WithExitHandler(exitHandler),
 		)
 
-		Expect(exitHandler.Calls[0].Arguments.Get(0)).To(MatchError(bard.IdentifiableError{
+		Expect(exitHandler.Calls[0].Arguments.Get(0)).To(MatchError(log.IdentifiableError{
 			Name:        "test-name",
 			Description: "test-version",
 			Err:         fmt.Errorf("test-error"),

--- a/internal/environment_writer.go
+++ b/internal/environment_writer.go
@@ -44,7 +44,7 @@ func WithEnvironmentWriterLogger(logger log.Logger) EnvironmentWriterOption {
 // NewEnvironmentWriter creates a new instance that writes to the filesystem and writes to the default log.Logger.
 func NewEnvironmentWriter(options ...EnvironmentWriterOption) EnvironmentWriter {
 	w := EnvironmentWriter{
-		logger: log.NewLogger(os.Stdout),
+		logger: log.NewPaketoLogger(os.Stdout),
 	}
 
 	for _, option := range options {

--- a/internal/environment_writer.go
+++ b/internal/environment_writer.go
@@ -22,29 +22,29 @@ import (
 	"path/filepath"
 	"sort"
 
-	"github.com/paketo-buildpacks/libpak/v2/bard"
+	"github.com/paketo-buildpacks/libpak/v2/log"
 )
 
 // EnvironmentWriter is an implementation of the libcnb.EnvironmentWriter interface.
 type EnvironmentWriter struct {
-	logger bard.Logger
+	logger log.Logger
 }
 
 // EnvironmentWriterOption is a function for configuring a EnvironmentWriter instance.
 type EnvironmentWriterOption func(writer EnvironmentWriter) EnvironmentWriter
 
 // WithEnvironmentWriterLogger creates an EnvironmentWriterOption that configures the logger.
-func WithEnvironmentWriterLogger(logger bard.Logger) EnvironmentWriterOption {
+func WithEnvironmentWriterLogger(logger log.Logger) EnvironmentWriterOption {
 	return func(writer EnvironmentWriter) EnvironmentWriter {
 		writer.logger = logger
 		return writer
 	}
 }
 
-// NewEnvironmentWriter creates a new instance that writes to the filesystem and writes to the default bard.Logger.
+// NewEnvironmentWriter creates a new instance that writes to the filesystem and writes to the default log.Logger.
 func NewEnvironmentWriter(options ...EnvironmentWriterOption) EnvironmentWriter {
 	w := EnvironmentWriter{
-		logger: bard.NewLogger(os.Stdout),
+		logger: log.NewLogger(os.Stdout),
 	}
 
 	for _, option := range options {

--- a/internal/environment_writer_test.go
+++ b/internal/environment_writer_test.go
@@ -25,8 +25,8 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/sclevine/spec"
 
-	"github.com/paketo-buildpacks/libpak/v2/bard"
 	"github.com/paketo-buildpacks/libpak/v2/internal"
+	"github.com/paketo-buildpacks/libpak/v2/log"
 )
 
 func testEnvironmentWriter(t *testing.T, context spec.G, it spec.S) {
@@ -85,7 +85,7 @@ func testEnvironmentWriter(t *testing.T, context spec.G, it spec.S) {
 
 		it.Before(func() {
 			b = bytes.NewBuffer(nil)
-			writer = internal.NewEnvironmentWriter(internal.WithEnvironmentWriterLogger(bard.NewLogger(b)))
+			writer = internal.NewEnvironmentWriter(internal.WithEnvironmentWriterLogger(log.NewLogger(b)))
 		})
 
 		it("logs environment", func() {

--- a/internal/environment_writer_test.go
+++ b/internal/environment_writer_test.go
@@ -41,7 +41,7 @@ func testEnvironmentWriter(t *testing.T, context spec.G, it spec.S) {
 		path = t.TempDir()
 		Expect(os.RemoveAll(path)).To(Succeed())
 
-		writer = internal.EnvironmentWriter{}
+		writer = internal.NewEnvironmentWriter()
 	})
 
 	it("writes the given environment to a directory", func() {
@@ -85,7 +85,7 @@ func testEnvironmentWriter(t *testing.T, context spec.G, it spec.S) {
 
 		it.Before(func() {
 			b = bytes.NewBuffer(nil)
-			writer = internal.NewEnvironmentWriter(internal.WithEnvironmentWriterLogger(log.NewLogger(b)))
+			writer = internal.NewEnvironmentWriter(internal.WithEnvironmentWriterLogger(log.NewPaketoLogger(b)))
 		})
 
 		it("logs environment", func() {

--- a/internal/exit_handler.go
+++ b/internal/exit_handler.go
@@ -73,7 +73,7 @@ func WithExitHandlerWriter(writer io.Writer) ExitHandlerOption {
 func NewExitHandler(options ...ExitHandlerOption) ExitHandler {
 	h := ExitHandler{
 		exitFunc: os.Exit,
-		logger:   log.NewLogger(os.Stdout),
+		logger:   log.NewPaketoLogger(os.Stdout),
 		writer:   os.Stderr,
 	}
 

--- a/internal/exit_handler.go
+++ b/internal/exit_handler.go
@@ -21,7 +21,7 @@ import (
 	"io"
 	"os"
 
-	"github.com/paketo-buildpacks/libpak/v2/bard"
+	"github.com/paketo-buildpacks/libpak/v2/log"
 )
 
 const (
@@ -38,7 +38,7 @@ const (
 // ExitHandler is an implementation of the libcnb.ExitHandler interface.
 type ExitHandler struct {
 	exitFunc func(int)
-	logger   bard.Logger
+	logger   log.Logger
 	writer   io.Writer
 }
 
@@ -54,7 +54,7 @@ func WithExitHandlerExitFunc(exitFunc func(int)) ExitHandlerOption {
 }
 
 // WithExitHandlerLogger creates an ExitHandlerOption that configures the logger.
-func WithExitHandlerLogger(logger bard.Logger) ExitHandlerOption {
+func WithExitHandlerLogger(logger log.Logger) ExitHandlerOption {
 	return func(handler ExitHandler) ExitHandler {
 		handler.logger = logger
 		return handler
@@ -69,11 +69,11 @@ func WithExitHandlerWriter(writer io.Writer) ExitHandlerOption {
 	}
 }
 
-// NewExitHandler creates a new instance that calls os.Exit and writes to the default bard.Logger and os.stderr.
+// NewExitHandler creates a new instance that calls os.Exit and writes to the default log.Logger and os.stderr.
 func NewExitHandler(options ...ExitHandlerOption) ExitHandler {
 	h := ExitHandler{
 		exitFunc: os.Exit,
-		logger:   bard.NewLogger(os.Stdout),
+		logger:   log.NewLogger(os.Stdout),
 		writer:   os.Stderr,
 	}
 
@@ -85,7 +85,7 @@ func NewExitHandler(options ...ExitHandlerOption) ExitHandler {
 }
 
 func (e ExitHandler) Error(err error) {
-	if i, ok := err.(bard.IdentifiableError); ok {
+	if i, ok := err.(log.IdentifiableError); ok {
 		e.logger.TerminalError(i)
 	} else {
 		_, _ = fmt.Fprintln(e.writer, err)

--- a/internal/exit_handler_test.go
+++ b/internal/exit_handler_test.go
@@ -43,7 +43,7 @@ func testExitHandler(t *testing.T, context spec.G, it spec.S) {
 
 		handler = internal.NewExitHandler(
 			internal.WithExitHandlerExitFunc(func(c int) { exitCode = c }),
-			internal.WithExitHandlerLogger(log.NewLogger(b)),
+			internal.WithExitHandlerLogger(log.NewPaketoLogger(b)),
 			internal.WithExitHandlerWriter(b),
 		)
 	})

--- a/internal/exit_handler_test.go
+++ b/internal/exit_handler_test.go
@@ -25,8 +25,8 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/sclevine/spec"
 
-	"github.com/paketo-buildpacks/libpak/v2/bard"
 	"github.com/paketo-buildpacks/libpak/v2/internal"
+	"github.com/paketo-buildpacks/libpak/v2/log"
 )
 
 func testExitHandler(t *testing.T, context spec.G, it spec.S) {
@@ -43,7 +43,7 @@ func testExitHandler(t *testing.T, context spec.G, it spec.S) {
 
 		handler = internal.NewExitHandler(
 			internal.WithExitHandlerExitFunc(func(c int) { exitCode = c }),
-			internal.WithExitHandlerLogger(bard.NewLogger(b)),
+			internal.WithExitHandlerLogger(log.NewLogger(b)),
 			internal.WithExitHandlerWriter(b),
 		)
 	})
@@ -69,7 +69,7 @@ func testExitHandler(t *testing.T, context spec.G, it spec.S) {
 	})
 
 	it("writes terminal error", func() {
-		handler.Error(bard.IdentifiableError{Name: "test-name", Description: "test-description", Err: fmt.Errorf("test-error")})
+		handler.Error(log.IdentifiableError{Name: "test-name", Description: "test-description", Err: fmt.Errorf("test-error")})
 		Expect(b).To(ContainSubstring("\x1b[31m\x1b[0m\n\x1b[31m\x1b[1mtest-name\x1b[0m\x1b[31m test-description\x1b[0m\n\x1b[31;1m  test-error\x1b[0m\n"))
 	})
 }

--- a/internal/toml_writer.go
+++ b/internal/toml_writer.go
@@ -26,30 +26,29 @@ import (
 	"github.com/BurntSushi/toml"
 	"github.com/buildpacks/libcnb/v2"
 	"github.com/heroku/color"
-
-	"github.com/paketo-buildpacks/libpak/v2/bard"
+	"github.com/paketo-buildpacks/libpak/v2/log"
 )
 
 // TOMLWriter is an implementation of the libcnb.TOMLWriter interface.
 type TOMLWriter struct {
-	logger bard.Logger
+	logger log.Logger
 }
 
 // TOMLWriterOption is a function for configuring a TOMLWriter instance.
 type TOMLWriterOption func(writer TOMLWriter) TOMLWriter
 
 // WithTOMLWriterLogger creates an TOMLWriterOption that configures the logger.
-func WithTOMLWriterLogger(logger bard.Logger) TOMLWriterOption {
+func WithTOMLWriterLogger(logger log.Logger) TOMLWriterOption {
 	return func(writer TOMLWriter) TOMLWriter {
 		writer.logger = logger
 		return writer
 	}
 }
 
-// NewTOMLWriter creates a new instance that writes to the filesystem and writes to the default bard.Logger.
+// NewTOMLWriter creates a new instance that writes to the filesystem and writes to the default log.Logger.
 func NewTOMLWriter(options ...TOMLWriterOption) TOMLWriter {
 	w := TOMLWriter{
-		logger: bard.NewLogger(os.Stdout),
+		logger: log.NewLogger(os.Stdout),
 	}
 
 	for _, option := range options {

--- a/internal/toml_writer.go
+++ b/internal/toml_writer.go
@@ -48,7 +48,7 @@ func WithTOMLWriterLogger(logger log.Logger) TOMLWriterOption {
 // NewTOMLWriter creates a new instance that writes to the filesystem and writes to the default log.Logger.
 func NewTOMLWriter(options ...TOMLWriterOption) TOMLWriter {
 	w := TOMLWriter{
-		logger: log.NewLogger(os.Stdout),
+		logger: log.NewPaketoLogger(os.Stdout),
 	}
 
 	for _, option := range options {

--- a/internal/toml_writer_test.go
+++ b/internal/toml_writer_test.go
@@ -65,7 +65,7 @@ other-field = "other-value"`))
 
 		it.Before(func() {
 			b = bytes.NewBuffer(nil)
-			tomlWriter = internal.NewTOMLWriter(internal.WithTOMLWriterLogger(log.NewLogger(b)))
+			tomlWriter = internal.NewTOMLWriter(internal.WithTOMLWriterLogger(log.NewPaketoLogger(b)))
 		})
 
 		it("does not log for uninteresting types", func() {

--- a/internal/toml_writer_test.go
+++ b/internal/toml_writer_test.go
@@ -28,8 +28,8 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/sclevine/spec"
 
-	"github.com/paketo-buildpacks/libpak/v2/bard"
 	"github.com/paketo-buildpacks/libpak/v2/internal"
+	"github.com/paketo-buildpacks/libpak/v2/log"
 )
 
 func testTOMLWriter(t *testing.T, context spec.G, it spec.S) {
@@ -65,7 +65,7 @@ other-field = "other-value"`))
 
 		it.Before(func() {
 			b = bytes.NewBuffer(nil)
-			tomlWriter = internal.NewTOMLWriter(internal.WithTOMLWriterLogger(bard.NewLogger(b)))
+			tomlWriter = internal.NewTOMLWriter(internal.WithTOMLWriterLogger(log.NewLogger(b)))
 		})
 
 		it("does not log for uninteresting types", func() {

--- a/layer.go
+++ b/layer.go
@@ -281,11 +281,12 @@ type HelperLayerContributor struct {
 }
 
 // NewHelperLayerContributor returns a new HelperLayerContributor
-func NewHelperLayerContributor(buildpack libcnb.Buildpack, names ...string) HelperLayerContributor {
+func NewHelperLayerContributor(buildpack libcnb.Buildpack, logger log.Logger, names ...string) HelperLayerContributor {
 	return HelperLayerContributor{
-		Path:          filepath.Join(buildpack.Path, "bin", "helper"),
-		Names:         names,
 		BuildpackInfo: buildpack.Info,
+		Logger:        logger,
+		Names:         names,
+		Path:          filepath.Join(buildpack.Path, "bin", "helper"),
 	}
 }
 

--- a/layer.go
+++ b/layer.go
@@ -192,7 +192,6 @@ func (l *LayerContributor) reset(layer *libcnb.Layer) error {
 // DependencyLayerContributor is a helper for implementing a Contributable for a BuildpackDependency in order
 // to get consistent logging and avoidance.
 type DependencyLayerContributor struct {
-
 	// Dependency is the dependency being contributed.
 	Dependency BuildModuleDependency
 
@@ -213,12 +212,13 @@ type DependencyLayerContributor struct {
 }
 
 // NewDependencyLayerContributor returns a new DependencyLayerContributor for the given BuildpackDependency
-func NewDependencyLayerContributor(dependency BuildModuleDependency, cache DependencyCache, types libcnb.LayerTypes) DependencyLayerContributor {
+func NewDependencyLayerContributor(dependency BuildModuleDependency, cache DependencyCache, types libcnb.LayerTypes, logger log.Logger) DependencyLayerContributor {
 	return DependencyLayerContributor{
 		Dependency:       dependency,
-		ExpectedMetadata: dependency,
 		DependencyCache:  cache,
+		ExpectedMetadata: dependency,
 		ExpectedTypes:    types,
+		Logger:           logger,
 	}
 }
 

--- a/layer.go
+++ b/layer.go
@@ -29,10 +29,9 @@ import (
 	"github.com/buildpacks/libcnb/v2"
 
 	"github.com/paketo-buildpacks/libpak/v2/internal"
+	"github.com/paketo-buildpacks/libpak/v2/log"
 	"github.com/paketo-buildpacks/libpak/v2/sbom"
 	"github.com/paketo-buildpacks/libpak/v2/sherpa"
-
-	"github.com/paketo-buildpacks/libpak/v2/bard"
 )
 
 // ContributableBuildFunc is a standard libcnb.BuildFunc implementation that delegates to a list of Contributables
@@ -74,7 +73,7 @@ type LayerContributor struct {
 	ExpectedMetadata interface{}
 
 	// Logger is the logger to use.
-	Logger bard.Logger
+	Logger log.Logger
 
 	// Name is the user readable name of the contribution.
 	Name string
@@ -84,7 +83,7 @@ type LayerContributor struct {
 }
 
 // NewLayerContributor creates a new instance.
-func NewLayerContributor(name string, expectedMetadata interface{}, expectedTypes libcnb.LayerTypes, logger bard.Logger) LayerContributor {
+func NewLayerContributor(name string, expectedMetadata interface{}, expectedTypes libcnb.LayerTypes, logger log.Logger) LayerContributor {
 	return LayerContributor{
 		ExpectedMetadata: expectedMetadata,
 		ExpectedTypes:    expectedTypes,
@@ -207,7 +206,7 @@ type DependencyLayerContributor struct {
 	ExpectedMetadata interface{}
 
 	// Logger is the logger to use.
-	Logger bard.Logger
+	Logger log.Logger
 
 	// RequestModifierFuncs is an optional Request Modifier to use when downloading the dependency.
 	RequestModifierFuncs []RequestModifierFunc
@@ -275,7 +274,7 @@ type HelperLayerContributor struct {
 	BuildpackInfo libcnb.BuildpackInfo
 
 	// Logger is the logger to use.
-	Logger bard.Logger
+	Logger log.Logger
 
 	// Names are the names of the helpers to create
 	Names []string

--- a/layer.go
+++ b/layer.go
@@ -35,10 +35,41 @@ import (
 	"github.com/paketo-buildpacks/libpak/v2/bard"
 )
 
-// LayerContributor is a helper for implementing a libcnb.LayerContributor in order to get consistent logging and
-// avoidance.
-type LayerContributor struct {
+// ContributableBuildFunc is a standard libcnb.BuildFunc implementation that delegates to a list of Contributables
+func ContributableBuildFunc(layerContributors []Contributable) libcnb.BuildFunc {
+	return func(context libcnb.BuildContext) (libcnb.BuildResult, error) {
+		result := libcnb.NewBuildResult()
 
+		for _, creator := range layerContributors {
+			name := creator.Name()
+			layer, err := context.Layers.Layer(name)
+			if err != nil {
+				return libcnb.BuildResult{}, fmt.Errorf("unable to create layer %s\n%w", name, err)
+			}
+
+			err = creator.Contribute(&layer)
+			if err != nil {
+				return libcnb.BuildResult{}, fmt.Errorf("unable to invoke layer creator\n%w", err)
+			}
+
+			result.Layers = append(result.Layers, layer)
+		}
+
+		return result, nil
+	}
+}
+
+// Contributable is an interface that is implemented when you want to contribute new layers
+type Contributable interface {
+	// Contribute accepts a new empty layer and transforms it
+	Contribute(layer *libcnb.Layer) error
+
+	// Name is the name of the layer.
+	Name() string
+}
+
+// LayerContributor is a helper for implementing Contributable in order to get consistent logging and avoidance.
+type LayerContributor struct {
 	// ExpectedMetadata is the metadata to compare against any existing layer metadata.
 	ExpectedMetadata interface{}
 
@@ -53,33 +84,34 @@ type LayerContributor struct {
 }
 
 // NewLayerContributor creates a new instance.
-func NewLayerContributor(name string, expectedMetadata interface{}, expectedTypes libcnb.LayerTypes) LayerContributor {
+func NewLayerContributor(name string, expectedMetadata interface{}, expectedTypes libcnb.LayerTypes, logger bard.Logger) LayerContributor {
 	return LayerContributor{
 		ExpectedMetadata: expectedMetadata,
-		Name:             name,
 		ExpectedTypes:    expectedTypes,
+		Logger:           logger,
+		Name:             name,
 	}
 }
 
 // LayerFunc is a callback function that is invoked when a layer needs to be contributed.
-type LayerFunc func() (libcnb.Layer, error)
+type LayerFunc func(*libcnb.Layer) error
 
-// Contribute is the function to call when implementing your libcnb.LayerContributor.
-func (l *LayerContributor) Contribute(layer libcnb.Layer, f LayerFunc) (libcnb.Layer, error) {
-	layerRestored, err := l.checkIfLayerRestored(layer)
+// Contribute is the function to call when implementing Contributable.
+func (l *LayerContributor) Contribute(layer *libcnb.Layer, f LayerFunc) error {
+	layerRestored, err := l.checkIfLayerRestored(*layer)
 	if err != nil {
-		return libcnb.Layer{}, fmt.Errorf("unable to check metadata\n%w", err)
+		return fmt.Errorf("unable to check metadata\n%w", err)
 	}
 
-	expected, cached, err := l.checkIfMetadataMatches(layer)
+	expected, cached, err := l.checkIfMetadataMatches(*layer)
 	if err != nil {
-		return libcnb.Layer{}, fmt.Errorf("unable to check metadata\n%w", err)
+		return fmt.Errorf("unable to check metadata\n%w", err)
 	}
 
 	if cached && layerRestored {
 		l.Logger.Headerf("%s: %s cached layer", color.BlueString(l.Name), color.GreenString("Reusing"))
 		layer.LayerTypes = l.ExpectedTypes
-		return layer, nil
+		return nil
 	}
 
 	if !layerRestored {
@@ -90,18 +122,18 @@ func (l *LayerContributor) Contribute(layer libcnb.Layer, f LayerFunc) (libcnb.L
 
 	err = l.reset(layer)
 	if err != nil {
-		return libcnb.Layer{}, fmt.Errorf("unable to reset\n%w", err)
+		return fmt.Errorf("unable to reset\n%w", err)
 	}
 
-	layer, err = f()
+	err = f(layer)
 	if err != nil {
-		return libcnb.Layer{}, err
+		return err
 	}
 
 	layer.LayerTypes = l.ExpectedTypes
 	layer.Metadata = expected
 
-	return layer, nil
+	return nil
 }
 
 func (l *LayerContributor) checkIfMetadataMatches(layer libcnb.Layer) (map[string]interface{}, bool, error) {
@@ -146,7 +178,7 @@ func (l *LayerContributor) checkIfLayerRestored(layer libcnb.Layer) (bool, error
 	return !(tomlExists && (!layerDirExists || len(dirContents) == 0) && (l.ExpectedTypes.Cache || l.ExpectedTypes.Build)), nil
 }
 
-func (l *LayerContributor) reset(layer libcnb.Layer) error {
+func (l *LayerContributor) reset(layer *libcnb.Layer) error {
 	if err := os.RemoveAll(layer.Path); err != nil {
 		return fmt.Errorf("unable to remove existing layer directory %s\n%w", layer.Path, err)
 	}
@@ -158,7 +190,7 @@ func (l *LayerContributor) reset(layer libcnb.Layer) error {
 	return nil
 }
 
-// DependencyLayerContributor is a helper for implementing a libcnb.LayerContributor for a BuildpackDependency in order
+// DependencyLayerContributor is a helper for implementing a Contributable for a BuildpackDependency in order
 // to get consistent logging and avoidance.
 type DependencyLayerContributor struct {
 
@@ -192,34 +224,33 @@ func NewDependencyLayerContributor(dependency BuildModuleDependency, cache Depen
 }
 
 // DependencyLayerFunc is a callback function that is invoked when a dependency needs to be contributed.
-type DependencyLayerFunc func(artifact *os.File) (libcnb.Layer, error)
+type DependencyLayerFunc func(layer *libcnb.Layer, artifact *os.File) error
 
-// Contribute is the function to call whe implementing your libcnb.LayerContributor.
-func (d *DependencyLayerContributor) Contribute(layer libcnb.Layer, f DependencyLayerFunc) (libcnb.Layer, error) {
-	lc := NewLayerContributor(d.Name(), d.ExpectedMetadata, d.ExpectedTypes)
-	lc.Logger = d.Logger
+// Contribute is the function to call whe implementing your Contributable.
+func (d *DependencyLayerContributor) Contribute(layer *libcnb.Layer, f DependencyLayerFunc) error {
+	lc := NewLayerContributor(d.Name(), d.ExpectedMetadata, d.ExpectedTypes, d.Logger)
 
-	return lc.Contribute(layer, func() (libcnb.Layer, error) {
+	return lc.Contribute(layer, func(_ *libcnb.Layer) error {
 		artifact, err := d.DependencyCache.Artifact(d.Dependency, d.RequestModifierFuncs...)
 		if err != nil {
-			return libcnb.Layer{}, fmt.Errorf("unable to get dependency %s\n%w", d.Dependency.ID, err)
+			return fmt.Errorf("unable to get dependency %s\n%w", d.Dependency.ID, err)
 		}
 		defer artifact.Close()
 
 		// Only buildpacks can create layers, so source must be buildpack.toml
 		sbomArtifact, err := d.Dependency.AsSyftArtifact("buildpack.toml")
 		if err != nil {
-			return libcnb.Layer{}, fmt.Errorf("unable to get SBOM artifact %s\n%w", d.Dependency.ID, err)
+			return fmt.Errorf("unable to get SBOM artifact %s\n%w", d.Dependency.ID, err)
 		}
 
 		sbomPath := layer.SBOMPath(libcnb.SyftJSON)
 		dep := sbom.NewSyftDependency(layer.Path, []sbom.SyftArtifact{sbomArtifact})
 		d.Logger.Debugf("Writing Syft SBOM at %s: %+v", sbomPath, dep)
 		if err := dep.WriteTo(sbomPath); err != nil {
-			return libcnb.Layer{}, fmt.Errorf("unable to write SBOM\n%w", err)
+			return fmt.Errorf("unable to write SBOM\n%w", err)
 		}
 
-		return f(artifact)
+		return f(layer, artifact)
 	})
 }
 
@@ -233,7 +264,7 @@ func (d *DependencyLayerContributor) Name() string {
 	return fmt.Sprintf("%s %s", d.Dependency.Name, d.Dependency.Version)
 }
 
-// HelperLayerContributor is a helper for implementing a libcnb.LayerContributor for a buildpack helper application in
+// HelperLayerContributor is a helper for implementing a Contributable for a buildpack helper application in
 // order to get consistent logging and avoidance.
 type HelperLayerContributor struct {
 
@@ -264,25 +295,23 @@ func (h HelperLayerContributor) Name() string {
 	return filepath.Base(h.Path)
 }
 
-// Contribute is the function to call whe implementing your libcnb.LayerContributor.
-func (h HelperLayerContributor) Contribute(layer libcnb.Layer) (libcnb.Layer, error) {
+// Contribute is the function to call whe implementing your Contributable.
+func (h HelperLayerContributor) Contribute(layer *libcnb.Layer) error {
 	expected := map[string]interface{}{"buildpackInfo": h.BuildpackInfo, "helperNames": h.Names}
 	lc := NewLayerContributor("Launch Helper", expected, libcnb.LayerTypes{
 		Launch: true,
-	})
+	}, h.Logger)
 
-	lc.Logger = h.Logger
-
-	return lc.Contribute(layer, func() (libcnb.Layer, error) {
+	return lc.Contribute(layer, func(_ *libcnb.Layer) error {
 		in, err := os.Open(h.Path)
 		if err != nil {
-			return libcnb.Layer{}, fmt.Errorf("unable to open %s\n%w", h.Path, err)
+			return fmt.Errorf("unable to open %s\n%w", h.Path, err)
 		}
 		defer in.Close()
 
 		out := filepath.Join(layer.Path, "helper")
 		if err := sherpa.CopyFile(in, out); err != nil {
-			return libcnb.Layer{}, fmt.Errorf("unable to copy %s to %s", h.Path, out)
+			return fmt.Errorf("unable to copy %s to %s", h.Path, out)
 		}
 
 		for _, n := range h.Names {
@@ -291,27 +320,27 @@ func (h HelperLayerContributor) Contribute(layer libcnb.Layer) (libcnb.Layer, er
 
 			f := filepath.Dir(link)
 			if err := os.MkdirAll(f, 0755); err != nil {
-				return libcnb.Layer{}, fmt.Errorf("unable to create %s\n%w", f, err)
+				return fmt.Errorf("unable to create %s\n%w", f, err)
 			}
 
 			if err := os.Symlink(out, link); err != nil {
-				return libcnb.Layer{}, fmt.Errorf("unable to link %s to %s\n%w", out, link, err)
+				return fmt.Errorf("unable to link %s to %s\n%w", out, link, err)
 			}
 		}
 
 		sbomArtifact, err := h.AsSyftArtifact()
 		if err != nil {
-			return libcnb.Layer{}, fmt.Errorf("unable to get SBOM artifact for helper\n%w", err)
+			return fmt.Errorf("unable to get SBOM artifact for helper\n%w", err)
 		}
 
 		sbomPath := layer.SBOMPath(libcnb.SyftJSON)
 		dep := sbom.NewSyftDependency(layer.Path, []sbom.SyftArtifact{sbomArtifact})
 		h.Logger.Debugf("Writing Syft SBOM at %s: %+v", sbomPath, dep)
 		if err := dep.WriteTo(sbomPath); err != nil {
-			return libcnb.Layer{}, fmt.Errorf("unable to write SBOM\n%w", err)
+			return fmt.Errorf("unable to write SBOM\n%w", err)
 		}
 
-		return layer, nil
+		return nil
 	})
 }
 

--- a/layer_test.go
+++ b/layer_test.go
@@ -52,10 +52,6 @@ func testLayer(t *testing.T, context spec.G, it spec.S) {
 		layer.Profile = libcnb.Profile{}
 	})
 
-	it.After(func() {
-		Expect(os.RemoveAll(layersDir)).To(Succeed())
-	})
-
 	context("LayerContributor", func() {
 		var (
 			lc libpak.LayerContributor

--- a/layer_test.go
+++ b/layer_test.go
@@ -31,7 +31,7 @@ import (
 	"github.com/sclevine/spec"
 
 	"github.com/paketo-buildpacks/libpak/v2"
-	"github.com/paketo-buildpacks/libpak/v2/bard"
+	"github.com/paketo-buildpacks/libpak/v2/log"
 )
 
 func testLayer(t *testing.T, context spec.G, it spec.S) {
@@ -62,7 +62,7 @@ func testLayer(t *testing.T, context spec.G, it spec.S) {
 		)
 
 		it.Before(func() {
-			lc.Logger = bard.NewLogger(bytes.NewBuffer(nil))
+			lc.Logger = log.NewLogger(bytes.NewBuffer(nil))
 			lc.ExpectedMetadata = map[string]interface{}{
 				"alpha": "test-alpha",
 				"bravo": map[string]interface{}{
@@ -318,7 +318,7 @@ func testLayer(t *testing.T, context spec.G, it spec.S) {
 
 			layer.Metadata = map[string]interface{}{}
 
-			dlc.Logger = bard.NewLogger(bytes.NewBuffer(nil))
+			dlc.Logger = log.NewLogger(bytes.NewBuffer(nil))
 			dlc.ExpectedMetadata = dependency
 			dlc.Dependency = dependency
 			dlc.DependencyCache.CachePath = layer.Path
@@ -538,7 +538,7 @@ func testLayer(t *testing.T, context spec.G, it spec.S) {
 			hlc = libpak.HelperLayerContributor{
 				Path:          file,
 				BuildpackInfo: buildpack.Info,
-				Logger:        bard.NewLogger(bytes.NewBuffer(nil)),
+				Logger:        log.NewLogger(bytes.NewBuffer(nil)),
 				Names:         []string{"test-name-1", "test-name-2"},
 			}
 		})

--- a/layer_test.go
+++ b/layer_test.go
@@ -62,7 +62,7 @@ func testLayer(t *testing.T, context spec.G, it spec.S) {
 		)
 
 		it.Before(func() {
-			lc.Logger = log.NewLogger(bytes.NewBuffer(nil))
+			lc.Logger = log.NewPaketoLogger(bytes.NewBuffer(nil))
 			lc.ExpectedMetadata = map[string]interface{}{
 				"alpha": "test-alpha",
 				"bravo": map[string]interface{}{
@@ -318,11 +318,12 @@ func testLayer(t *testing.T, context spec.G, it spec.S) {
 
 			layer.Metadata = map[string]interface{}{}
 
-			dlc.Logger = log.NewLogger(bytes.NewBuffer(nil))
+			dlc.Logger = log.NewDiscardLogger()
 			dlc.ExpectedMetadata = dependency
 			dlc.Dependency = dependency
 			dlc.DependencyCache.CachePath = layer.Path
 			dlc.DependencyCache.DownloadPath = layer.Path
+			dlc.DependencyCache.Logger = log.NewDiscardLogger()
 		})
 
 		it.After(func() {
@@ -538,7 +539,7 @@ func testLayer(t *testing.T, context spec.G, it spec.S) {
 			hlc = libpak.HelperLayerContributor{
 				Path:          file,
 				BuildpackInfo: buildpack.Info,
-				Logger:        log.NewLogger(bytes.NewBuffer(nil)),
+				Logger:        log.NewPaketoLogger(bytes.NewBuffer(nil)),
 				Names:         []string{"test-name-1", "test-name-2"},
 			}
 		})

--- a/layer_test.go
+++ b/layer_test.go
@@ -39,11 +39,12 @@ func testLayer(t *testing.T, context spec.G, it spec.S) {
 		Expect = NewWithT(t).Expect
 
 		layersDir string
-		layer     libcnb.Layer
+		layer     *libcnb.Layer
 	)
 
 	it.Before(func() {
 		layersDir = t.TempDir()
+		layer = &libcnb.Layer{}
 		layer.Path = filepath.Join(layersDir, "test-layer")
 
 		layer.Exec.Path = layer.Path
@@ -74,9 +75,9 @@ func testLayer(t *testing.T, context spec.G, it spec.S) {
 		it("calls function with no existing metadata", func() {
 			var called bool
 
-			_, err := lc.Contribute(layer, func() (libcnb.Layer, error) {
+			err := lc.Contribute(layer, func(layer *libcnb.Layer) error {
 				called = true
-				return layer, nil
+				return nil
 			})
 			Expect(err).NotTo(HaveOccurred())
 
@@ -89,9 +90,9 @@ func testLayer(t *testing.T, context spec.G, it spec.S) {
 
 			var called bool
 
-			_, err := lc.Contribute(layer, func() (libcnb.Layer, error) {
+			err := lc.Contribute(layer, func(layer *libcnb.Layer) error {
 				called = true
-				return layer, nil
+				return nil
 			})
 			Expect(err).NotTo(HaveOccurred())
 
@@ -117,9 +118,9 @@ func testLayer(t *testing.T, context spec.G, it spec.S) {
 				Expect(os.RemoveAll(layer.Path)).To(Succeed())
 				lc.ExpectedTypes.Cache = true
 
-				_, err := lc.Contribute(layer, func() (libcnb.Layer, error) {
+				err := lc.Contribute(layer, func(layer *libcnb.Layer) error {
 					called = true
-					return layer, nil
+					return nil
 				})
 				Expect(err).NotTo(HaveOccurred())
 
@@ -131,9 +132,9 @@ func testLayer(t *testing.T, context spec.G, it spec.S) {
 				Expect(os.RemoveAll(layer.Path)).To(Succeed())
 				lc.ExpectedTypes.Build = true
 
-				_, err := lc.Contribute(layer, func() (libcnb.Layer, error) {
+				err := lc.Contribute(layer, func(layer *libcnb.Layer) error {
 					called = true
-					return layer, nil
+					return nil
 				})
 				Expect(err).NotTo(HaveOccurred())
 
@@ -145,9 +146,9 @@ func testLayer(t *testing.T, context spec.G, it spec.S) {
 				Expect(os.MkdirAll(layer.Path, 0755)).To(Succeed())
 				lc.ExpectedTypes.Build = true
 
-				_, err := lc.Contribute(layer, func() (libcnb.Layer, error) {
+				err := lc.Contribute(layer, func(layer *libcnb.Layer) error {
 					called = true
-					return layer, nil
+					return nil
 				})
 				Expect(err).NotTo(HaveOccurred())
 
@@ -160,9 +161,9 @@ func testLayer(t *testing.T, context spec.G, it spec.S) {
 				Expect(os.WriteFile(filepath.Join(layer.Path, "foo"), []byte{}, 0644)).To(Succeed())
 				lc.ExpectedTypes.Build = true
 
-				_, err := lc.Contribute(layer, func() (libcnb.Layer, error) {
+				err := lc.Contribute(layer, func(layer *libcnb.Layer) error {
 					called = true
-					return layer, nil
+					return nil
 				})
 				Expect(err).NotTo(HaveOccurred())
 
@@ -173,9 +174,9 @@ func testLayer(t *testing.T, context spec.G, it spec.S) {
 				Expect(os.MkdirAll(layer.Path, 0755)).To(Succeed())
 				layer.Build = true
 
-				_, err := lc.Contribute(layer, func() (libcnb.Layer, error) {
+				err := lc.Contribute(layer, func(layer *libcnb.Layer) error {
 					called = true
-					return layer, nil
+					return nil
 				})
 				Expect(err).NotTo(HaveOccurred())
 
@@ -194,9 +195,9 @@ func testLayer(t *testing.T, context spec.G, it spec.S) {
 
 			var called bool
 
-			_, err := lc.Contribute(layer, func() (libcnb.Layer, error) {
+			err := lc.Contribute(layer, func(layer *libcnb.Layer) error {
 				called = true
-				return layer, nil
+				return nil
 			})
 			Expect(err).NotTo(HaveOccurred())
 
@@ -204,15 +205,15 @@ func testLayer(t *testing.T, context spec.G, it spec.S) {
 		})
 
 		it("returns function error", func() {
-			_, err := lc.Contribute(layer, func() (libcnb.Layer, error) {
-				return libcnb.Layer{}, fmt.Errorf("test-error")
+			err := lc.Contribute(layer, func(layer *libcnb.Layer) error {
+				return fmt.Errorf("test-error")
 			})
 			Expect(err).To(MatchError("test-error"))
 		})
 
 		it("adds expected metadata to layer", func() {
-			layer, err := lc.Contribute(layer, func() (libcnb.Layer, error) {
-				return layer, nil
+			err := lc.Contribute(layer, func(layer *libcnb.Layer) error {
+				return nil
 			})
 			Expect(err).NotTo(HaveOccurred())
 
@@ -227,8 +228,8 @@ func testLayer(t *testing.T, context spec.G, it spec.S) {
 
 		it("sets build layer flag", func() {
 			lc.ExpectedTypes.Build = true
-			layer, err := lc.Contribute(layer, func() (libcnb.Layer, error) {
-				return layer, nil
+			err := lc.Contribute(layer, func(layer *libcnb.Layer) error {
+				return nil
 			})
 			Expect(err).NotTo(HaveOccurred())
 
@@ -237,8 +238,8 @@ func testLayer(t *testing.T, context spec.G, it spec.S) {
 
 		it("sets cache layer flag", func() {
 			lc.ExpectedTypes.Cache = true
-			layer, err := lc.Contribute(layer, func() (libcnb.Layer, error) {
-				return layer, nil
+			err := lc.Contribute(layer, func(layer *libcnb.Layer) error {
+				return nil
 			})
 			Expect(err).NotTo(HaveOccurred())
 
@@ -247,8 +248,8 @@ func testLayer(t *testing.T, context spec.G, it spec.S) {
 
 		it("sets launch layer flag", func() {
 			lc.ExpectedTypes.Launch = true
-			layer, err := lc.Contribute(layer, func() (libcnb.Layer, error) {
-				return layer, nil
+			err := lc.Contribute(layer, func(layer *libcnb.Layer) error {
+				return nil
 			})
 			Expect(err).NotTo(HaveOccurred())
 
@@ -270,9 +271,9 @@ func testLayer(t *testing.T, context spec.G, it spec.S) {
 
 			var called bool
 
-			layer, err := lc.Contribute(layer, func() (libcnb.Layer, error) {
+			err := lc.Contribute(layer, func(layer *libcnb.Layer) error {
 				called = true
-				return layer, nil
+				return nil
 			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(called).To(BeFalse())
@@ -333,11 +334,11 @@ func testLayer(t *testing.T, context spec.G, it spec.S) {
 
 			var called bool
 
-			_, err := dlc.Contribute(layer, func(artifact *os.File) (libcnb.Layer, error) {
+			err := dlc.Contribute(layer, func(layer *libcnb.Layer, artifact *os.File) error {
 				defer artifact.Close()
 
 				called = true
-				return layer, nil
+				return nil
 			})
 			Expect(err).NotTo(HaveOccurred())
 
@@ -355,9 +356,9 @@ func testLayer(t *testing.T, context spec.G, it spec.S) {
 				return request, nil
 			})
 
-			_, err := dlc.Contribute(layer, func(artifact *os.File) (libcnb.Layer, error) {
+			err := dlc.Contribute(layer, func(layer *libcnb.Layer, artifact *os.File) error {
 				defer artifact.Close()
-				return layer, nil
+				return nil
 			})
 			Expect(err).NotTo(HaveOccurred())
 		})
@@ -369,11 +370,11 @@ func testLayer(t *testing.T, context spec.G, it spec.S) {
 
 			var called bool
 
-			_, err := dlc.Contribute(layer, func(artifact *os.File) (libcnb.Layer, error) {
+			err := dlc.Contribute(layer, func(layer *libcnb.Layer, artifact *os.File) error {
 				defer artifact.Close()
 
 				called = true
-				return layer, nil
+				return nil
 			})
 			Expect(err).NotTo(HaveOccurred())
 
@@ -401,11 +402,11 @@ func testLayer(t *testing.T, context spec.G, it spec.S) {
 
 			var called bool
 
-			_, err := dlc.Contribute(layer, func(artifact *os.File) (libcnb.Layer, error) {
+			err := dlc.Contribute(layer, func(layer *libcnb.Layer, artifact *os.File) error {
 				defer artifact.Close()
 
 				called = true
-				return layer, nil
+				return nil
 			})
 			Expect(err).NotTo(HaveOccurred())
 
@@ -415,10 +416,10 @@ func testLayer(t *testing.T, context spec.G, it spec.S) {
 		it("returns function error", func() {
 			server.AppendHandlers(ghttp.RespondWith(http.StatusOK, "test-fixture"))
 
-			_, err := dlc.Contribute(layer, func(artifact *os.File) (libcnb.Layer, error) {
+			err := dlc.Contribute(layer, func(layer *libcnb.Layer, artifact *os.File) error {
 				defer artifact.Close()
 
-				return libcnb.Layer{}, fmt.Errorf("test-error")
+				return fmt.Errorf("test-error")
 			})
 			Expect(err).To(MatchError("test-error"))
 		})
@@ -426,9 +427,9 @@ func testLayer(t *testing.T, context spec.G, it spec.S) {
 		it("adds expected metadata to layer", func() {
 			server.AppendHandlers(ghttp.RespondWith(http.StatusOK, "test-fixture"))
 
-			layer, err := dlc.Contribute(layer, func(artifact *os.File) (libcnb.Layer, error) {
+			err := dlc.Contribute(layer, func(layer *libcnb.Layer, artifact *os.File) error {
 				defer artifact.Close()
-				return layer, nil
+				return nil
 			})
 			Expect(err).NotTo(HaveOccurred())
 
@@ -475,11 +476,11 @@ func testLayer(t *testing.T, context spec.G, it spec.S) {
 
 			var called bool
 
-			layer, err := dlc.Contribute(layer, func(artifact *os.File) (libcnb.Layer, error) {
+			err := dlc.Contribute(layer, func(layer *libcnb.Layer, artifact *os.File) error {
 				defer artifact.Close()
 
 				called = true
-				return layer, nil
+				return nil
 			})
 			Expect(err).NotTo(HaveOccurred())
 
@@ -493,9 +494,9 @@ func testLayer(t *testing.T, context spec.G, it spec.S) {
 		it("adds expected Syft SBOM file", func() {
 			server.AppendHandlers(ghttp.RespondWith(http.StatusOK, "test-fixture"))
 
-			layer, err := dlc.Contribute(layer, func(artifact *os.File) (libcnb.Layer, error) {
+			err := dlc.Contribute(layer, func(layer *libcnb.Layer, artifact *os.File) error {
 				defer artifact.Close()
-				return layer, nil
+				return nil
 			})
 			Expect(err).NotTo(HaveOccurred())
 
@@ -547,7 +548,7 @@ func testLayer(t *testing.T, context spec.G, it spec.S) {
 		})
 
 		it("calls function with no existing metadata", func() {
-			_, err := hlc.Contribute(layer)
+			err := hlc.Contribute(layer)
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(filepath.Join(layer.Exec.FilePath("test-name-1"))).To(BeAnExistingFile())
@@ -556,7 +557,7 @@ func testLayer(t *testing.T, context spec.G, it spec.S) {
 		it("calls function with non-matching metadata", func() {
 			layer.Metadata["alpha"] = "other-alpha"
 
-			_, err := hlc.Contribute(layer)
+			err := hlc.Contribute(layer)
 			Expect(err).NotTo(HaveOccurred())
 
 			file := filepath.Join(layer.Exec.FilePath("test-name-1"))
@@ -580,7 +581,7 @@ func testLayer(t *testing.T, context spec.G, it spec.S) {
 			layer.Metadata["buildpackInfo"] = buildpackInfo
 			layer.Metadata["helperNames"] = []interface{}{hlc.Names[0], hlc.Names[1]}
 
-			_, err := hlc.Contribute(layer)
+			err := hlc.Contribute(layer)
 
 			Expect(err).NotTo(HaveOccurred())
 
@@ -589,7 +590,7 @@ func testLayer(t *testing.T, context spec.G, it spec.S) {
 		})
 
 		it("adds expected metadata to layer", func() {
-			layer, err := hlc.Contribute(layer)
+			err := hlc.Contribute(layer)
 			Expect(err).NotTo(HaveOccurred())
 
 			buildpackInfo := map[string]interface{}{
@@ -617,7 +618,7 @@ func testLayer(t *testing.T, context spec.G, it spec.S) {
 
 			// Launch is the only one set & always true
 
-			layer, err := hlc.Contribute(layer)
+			err := hlc.Contribute(layer)
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(filepath.Join(layer.Exec.FilePath("test-name-1"))).NotTo(BeAnExistingFile())
@@ -631,7 +632,7 @@ func testLayer(t *testing.T, context spec.G, it spec.S) {
 		it("adds expected Syft SBOM file", func() {
 			layer.Metadata = map[string]interface{}{}
 
-			_, err := hlc.Contribute(layer)
+			err := hlc.Contribute(layer)
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(filepath.Join(layer.Exec.FilePath("test-name-1"))).To(BeAnExistingFile())

--- a/log/formatter.go
+++ b/log/formatter.go
@@ -14,19 +14,21 @@
  * limitations under the License.
  */
 
-package bard_test
+package log
 
 import (
-	"testing"
+	"fmt"
 
-	"github.com/sclevine/spec"
-	"github.com/sclevine/spec/report"
+	"github.com/heroku/color"
 )
 
-func TestUnit(t *testing.T) {
-	suite := spec.New("libpak/bard", spec.Report(report.Terminal{}))
-	suite("Logger", testLogger)
-	suite("Formatter", testFormatter)
-	suite("Writer", testWriter)
-	suite.Run(t)
+// FormatIdentity formats a name and an optional description in the form '<b>name</b>[ description]'.
+func FormatIdentity(name string, description string) string {
+	s := color.New(color.Bold).Sprint(name)
+
+	if description != "" {
+		s += fmt.Sprintf(" %s", description)
+	}
+
+	return s
 }

--- a/log/formatter_test.go
+++ b/log/formatter_test.go
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package bard_test
+package log_test
 
 import (
 	"fmt"
@@ -22,9 +22,8 @@ import (
 
 	"github.com/heroku/color"
 	. "github.com/onsi/gomega"
+	"github.com/paketo-buildpacks/libpak/v2/log"
 	"github.com/sclevine/spec"
-
-	"github.com/paketo-buildpacks/libpak/v2/bard"
 )
 
 func testFormatter(t *testing.T, context spec.G, it spec.S) {
@@ -35,12 +34,12 @@ func testFormatter(t *testing.T, context spec.G, it spec.S) {
 	context("FormatIdentity", func() {
 
 		it("it formats name", func() {
-			Expect(bard.FormatIdentity("test-name", "")).
+			Expect(log.FormatIdentity("test-name", "")).
 				To(Equal(color.New(color.Bold).Sprint("test-name")))
 		})
 
 		it("formats name and description", func() {
-			Expect(bard.FormatIdentity("test-name", "test-description")).
+			Expect(log.FormatIdentity("test-name", "test-description")).
 				To(Equal(fmt.Sprintf("%s test-description", color.New(color.Bold).Sprint("test-name"))))
 		})
 	})

--- a/log/init_test.go
+++ b/log/init_test.go
@@ -14,21 +14,19 @@
  * limitations under the License.
  */
 
-package bard
+package log_test
 
 import (
-	"fmt"
+	"testing"
 
-	"github.com/heroku/color"
+	"github.com/sclevine/spec"
+	"github.com/sclevine/spec/report"
 )
 
-// FormatIdentity formats a name and an optional description in the form '<b>name</b>[ description]'.
-func FormatIdentity(name string, description string) string {
-	s := color.New(color.Bold).Sprint(name)
-
-	if description != "" {
-		s += fmt.Sprintf(" %s", description)
-	}
-
-	return s
+func TestUnit(t *testing.T) {
+	suite := spec.New("libpak/log", spec.Report(report.Terminal{}))
+	suite("Logger", testLogger)
+	suite("Formatter", testFormatter)
+	suite("Writer", testWriter)
+	suite.Run(t)
 }

--- a/log/logger.go
+++ b/log/logger.go
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package bard
+package log
 
 import (
 	"fmt"

--- a/log/logger.go
+++ b/log/logger.go
@@ -64,7 +64,7 @@ type PaketoLogger struct {
 	title          io.Writer
 }
 
-// NewDiscard creates a new instance of PaketoLogger that discards all log messages. Useful in testing.
+// NewDiscardLogger creates a new instance of PaketoLogger that discards all log messages. Useful in testing.
 func NewDiscardLogger() PaketoLogger {
 	return PaketoLogger{
 		debug:          io.Discard,

--- a/log/logger_test.go
+++ b/log/logger_test.go
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package bard_test
+package log_test
 
 import (
 	"bytes"
@@ -23,9 +23,8 @@ import (
 	"testing"
 
 	. "github.com/onsi/gomega"
+	"github.com/paketo-buildpacks/libpak/v2/log"
 	"github.com/sclevine/spec"
-
-	"github.com/paketo-buildpacks/libpak/v2/bard"
 )
 
 func testLogger(t *testing.T, context spec.G, it spec.S) {
@@ -33,7 +32,7 @@ func testLogger(t *testing.T, context spec.G, it spec.S) {
 		Expect = NewWithT(t).Expect
 
 		b *bytes.Buffer
-		l bard.Logger
+		l log.Logger
 	)
 
 	it.Before(func() {
@@ -42,7 +41,7 @@ func testLogger(t *testing.T, context spec.G, it spec.S) {
 
 	context("without BP_DEBUG", func() {
 		it.Before(func() {
-			l = bard.NewLogger(b)
+			l = log.NewLogger(b)
 		})
 
 		it("does not configure debug", func() {
@@ -55,7 +54,7 @@ func testLogger(t *testing.T, context spec.G, it spec.S) {
 			//libcnb defines BP_DEBUG as enabled if it has _any_ value
 			//this does not include empty string as previously tested here.
 			Expect(os.Setenv("BP_DEBUG", "true")).To(Succeed())
-			l = bard.NewLogger(b)
+			l = log.NewLogger(b)
 		})
 
 		it.After(func() {
@@ -70,7 +69,7 @@ func testLogger(t *testing.T, context spec.G, it spec.S) {
 	context("with BP_LOG_LEVEL set to DEBUG", func() {
 		it.Before(func() {
 			Expect(os.Setenv("BP_LOG_LEVEL", "DEBUG")).To(Succeed())
-			l = bard.NewLogger(b)
+			l = log.NewLogger(b)
 		})
 
 		it.After(func() {
@@ -85,7 +84,7 @@ func testLogger(t *testing.T, context spec.G, it spec.S) {
 	context("with debug disabled", func() {
 		it.Before(func() {
 			Expect(os.Unsetenv("BP_LOG_LEVEL")).To(Succeed())
-			l = bard.NewLoggerWithOptions(b)
+			l = log.NewLoggerWithOptions(b)
 		})
 
 		it("does not write debug log", func() {
@@ -106,7 +105,7 @@ func testLogger(t *testing.T, context spec.G, it spec.S) {
 	context("with debug enabled", func() {
 		it.Before(func() {
 			Expect(os.Setenv("BP_LOG_LEVEL", "debug")).To(Succeed())
-			l = bard.NewLogger(b)
+			l = log.NewLogger(b)
 		})
 		it.After(func() {
 			Expect(os.Unsetenv("BP_LOG_LEVEL")).To(Succeed())
@@ -163,7 +162,7 @@ func testLogger(t *testing.T, context spec.G, it spec.S) {
 		})
 
 		it("writes terminal error", func() {
-			l.TerminalError(bard.IdentifiableError{Name: "test-name", Description: "test-description", Err: fmt.Errorf("test-error")})
+			l.TerminalError(log.IdentifiableError{Name: "test-name", Description: "test-description", Err: fmt.Errorf("test-error")})
 			Expect(b.String()).To(Equal("\x1b[31m\x1b[0m\n\x1b[31m\x1b[1mtest-name\x1b[0m\x1b[31m test-description\x1b[0m\n\x1b[31;1m  test-error\x1b[0m\n"))
 		})
 

--- a/log/logger_test.go
+++ b/log/logger_test.go
@@ -41,7 +41,7 @@ func testLogger(t *testing.T, context spec.G, it spec.S) {
 
 	context("without BP_DEBUG", func() {
 		it.Before(func() {
-			l = log.NewLogger(b)
+			l = log.NewPaketoLogger(b)
 		})
 
 		it("does not configure debug", func() {
@@ -53,12 +53,8 @@ func testLogger(t *testing.T, context spec.G, it spec.S) {
 		it.Before(func() {
 			//libcnb defines BP_DEBUG as enabled if it has _any_ value
 			//this does not include empty string as previously tested here.
-			Expect(os.Setenv("BP_DEBUG", "true")).To(Succeed())
-			l = log.NewLogger(b)
-		})
-
-		it.After(func() {
-			Expect(os.Unsetenv("BP_DEBUG")).To(Succeed())
+			t.Setenv("BP_DEBUG", "true")
+			l = log.NewPaketoLogger(b)
 		})
 
 		it("configures debug", func() {
@@ -68,12 +64,8 @@ func testLogger(t *testing.T, context spec.G, it spec.S) {
 
 	context("with BP_LOG_LEVEL set to DEBUG", func() {
 		it.Before(func() {
-			Expect(os.Setenv("BP_LOG_LEVEL", "DEBUG")).To(Succeed())
-			l = log.NewLogger(b)
-		})
-
-		it.After(func() {
-			Expect(os.Unsetenv("BP_LOG_LEVEL")).To(Succeed())
+			t.Setenv("BP_LOG_LEVEL", "DEBUG")
+			l = log.NewPaketoLogger(b)
 		})
 
 		it("configures debug", func() {
@@ -84,7 +76,7 @@ func testLogger(t *testing.T, context spec.G, it spec.S) {
 	context("with debug disabled", func() {
 		it.Before(func() {
 			Expect(os.Unsetenv("BP_LOG_LEVEL")).To(Succeed())
-			l = log.NewLoggerWithOptions(b)
+			l = log.NewPaketoLoggerWithOptions(b)
 		})
 
 		it("does not write debug log", func() {
@@ -104,11 +96,8 @@ func testLogger(t *testing.T, context spec.G, it spec.S) {
 
 	context("with debug enabled", func() {
 		it.Before(func() {
-			Expect(os.Setenv("BP_LOG_LEVEL", "debug")).To(Succeed())
-			l = log.NewLogger(b)
-		})
-		it.After(func() {
-			Expect(os.Unsetenv("BP_LOG_LEVEL")).To(Succeed())
+			t.Setenv("BP_LOG_LEVEL", "debug")
+			l = log.NewPaketoLogger(b)
 		})
 
 		it("writes body log", func() {
@@ -131,12 +120,12 @@ func testLogger(t *testing.T, context spec.G, it spec.S) {
 
 		it("writes debug log", func() {
 			l.Debug("test-message")
-			Expect(b.String()).To(Equal("test-message\n"))
+			Expect(b.String()).To(Equal("\x1b[46mtest-message\x1b[0m\n"))
 		})
 
 		it("writes debug formatted log", func() {
 			l.Debugf("test-%s", "message")
-			Expect(b.String()).To(Equal("test-message\n"))
+			Expect(b.String()).To(Equal("\x1b[46mtest-message\x1b[0m\n"))
 		})
 
 		it("returns debug writer", func() {

--- a/log/writer.go
+++ b/log/writer.go
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package bard
+package log
 
 import (
 	"bytes"

--- a/log/writer_test.go
+++ b/log/writer_test.go
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package bard_test
+package log_test
 
 import (
 	"bytes"
@@ -22,9 +22,8 @@ import (
 
 	"github.com/heroku/color"
 	. "github.com/onsi/gomega"
+	"github.com/paketo-buildpacks/libpak/v2/log"
 	"github.com/sclevine/spec"
-
-	"github.com/paketo-buildpacks/libpak/v2/bard"
 )
 
 func testWriter(t *testing.T, context spec.G, it spec.S) {
@@ -35,12 +34,12 @@ func testWriter(t *testing.T, context spec.G, it spec.S) {
 	context("Writer", func() {
 		var (
 			buffer *bytes.Buffer
-			writer *bard.Writer
+			writer *log.Writer
 		)
 
 		it.Before(func() {
 			buffer = bytes.NewBuffer(nil)
-			writer = bard.NewWriter(buffer)
+			writer = log.NewWriter(buffer)
 		})
 
 		context("Write", func() {
@@ -52,7 +51,7 @@ func testWriter(t *testing.T, context spec.G, it spec.S) {
 
 			context("when the writer has a color", func() {
 				it.Before(func() {
-					writer = bard.NewWriter(buffer, bard.WithAttributes(color.FgBlue))
+					writer = log.NewWriter(buffer, log.WithAttributes(color.FgBlue))
 				})
 
 				it("prints to the writer with the correct color codes", func() {
@@ -64,7 +63,7 @@ func testWriter(t *testing.T, context spec.G, it spec.S) {
 
 			context("when the writer has an indent", func() {
 				it.Before(func() {
-					writer = bard.NewWriter(buffer, bard.WithIndent(2))
+					writer = log.NewWriter(buffer, log.WithIndent(2))
 				})
 
 				it("prints to the writer with the correct indentation", func() {
@@ -76,7 +75,7 @@ func testWriter(t *testing.T, context spec.G, it spec.S) {
 
 			context("when the writer has a return prefix", func() {
 				it.Before(func() {
-					writer = bard.NewWriter(buffer, bard.WithAttributes(color.FgRed), bard.WithIndent(2))
+					writer = log.NewWriter(buffer, log.WithAttributes(color.FgRed), log.WithIndent(2))
 				})
 
 				it("prints to the writer with the correct indentation", func() {
@@ -88,7 +87,7 @@ func testWriter(t *testing.T, context spec.G, it spec.S) {
 
 			context("when the writer has a newline suffix", func() {
 				it.Before(func() {
-					writer = bard.NewWriter(buffer, bard.WithAttributes(color.FgRed), bard.WithIndent(2))
+					writer = log.NewWriter(buffer, log.WithAttributes(color.FgRed), log.WithIndent(2))
 				})
 
 				it("prints to the writer with the correct indentation", func() {
@@ -100,7 +99,7 @@ func testWriter(t *testing.T, context spec.G, it spec.S) {
 
 			context("when there is multiple input", func() {
 				it.Before(func() {
-					writer = bard.NewWriter(buffer, bard.WithIndent(2))
+					writer = log.NewWriter(buffer, log.WithIndent(2))
 				})
 
 				it("skips indentation if there was not a line break", func() {
@@ -126,7 +125,7 @@ func testWriter(t *testing.T, context spec.G, it spec.S) {
 
 			context("when the input has a percent symbol", func() {
 				it.Before(func() {
-					writer = bard.NewWriter(buffer, bard.WithAttributes(color.FgMagenta))
+					writer = log.NewWriter(buffer, log.WithAttributes(color.FgMagenta))
 				})
 
 				it("prints to the writer with the correct indentation", func() {

--- a/sbom/sbom.go
+++ b/sbom/sbom.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/buildpacks/libcnb/v2"
 	"github.com/mitchellh/hashstructure/v2"
-	"github.com/paketo-buildpacks/libpak/v2/bard"
 	"github.com/paketo-buildpacks/libpak/v2/effect"
+	"github.com/paketo-buildpacks/libpak/v2/log"
 )
 
 //go:generate mockery --name SBOMScanner --case=underscore
@@ -105,10 +105,10 @@ type SyftSchema struct {
 type SyftCLISBOMScanner struct {
 	Executor effect.Executor
 	Layers   libcnb.Layers
-	Logger   bard.Logger
+	Logger   log.Logger
 }
 
-func NewSyftCLISBOMScanner(layers libcnb.Layers, executor effect.Executor, logger bard.Logger) SyftCLISBOMScanner {
+func NewSyftCLISBOMScanner(layers libcnb.Layers, executor effect.Executor, logger log.Logger) SyftCLISBOMScanner {
 	return SyftCLISBOMScanner{
 		Executor: executor,
 		Layers:   layers,

--- a/sbom/sbom_test.go
+++ b/sbom/sbom_test.go
@@ -1,7 +1,6 @@
 package sbom_test
 
 import (
-	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -62,7 +61,7 @@ func testSBOM(t *testing.T, context spec.G, it spec.S) {
 			}).Return(nil)
 
 			// uses interface here intentionally, to force that inteface and implementation match
-			scanner = sbom.NewSyftCLISBOMScanner(layers, &executor, log.NewLogger(io.Discard))
+			scanner = sbom.NewSyftCLISBOMScanner(layers, &executor, log.NewDiscardLogger())
 
 			Expect(scanner.ScanBuild("something", format)).To(Succeed())
 
@@ -105,7 +104,7 @@ func testSBOM(t *testing.T, context spec.G, it spec.S) {
 			}).Return(nil)
 
 			// uses interface here intentionally, to force that inteface and implementation match
-			scanner = sbom.NewSyftCLISBOMScanner(layers, &executor, log.NewLogger(io.Discard))
+			scanner = sbom.NewSyftCLISBOMScanner(layers, &executor, log.NewDiscardLogger())
 
 			Expect(scanner.ScanBuild("something", format)).To(Succeed())
 
@@ -133,7 +132,7 @@ func testSBOM(t *testing.T, context spec.G, it spec.S) {
 			scanner := sbom.SyftCLISBOMScanner{
 				Executor: &executor,
 				Layers:   layers,
-				Logger:   log.NewLogger(io.Discard),
+				Logger:   log.NewDiscardLogger(),
 			}
 
 			Expect(scanner.ScanLayer(layer, "something", format)).To(Succeed())
@@ -160,7 +159,7 @@ func testSBOM(t *testing.T, context spec.G, it spec.S) {
 			scanner := sbom.SyftCLISBOMScanner{
 				Executor: &executor,
 				Layers:   layers,
-				Logger:   log.NewLogger(io.Discard),
+				Logger:   log.NewDiscardLogger(),
 			}
 
 			Expect(scanner.ScanLaunch("something", libcnb.CycloneDXJSON, libcnb.SyftJSON, libcnb.SPDXJSON)).To(Succeed())

--- a/sbom/sbom_test.go
+++ b/sbom/sbom_test.go
@@ -9,9 +9,9 @@ import (
 
 	"github.com/buildpacks/libcnb/v2"
 	. "github.com/onsi/gomega"
-	"github.com/paketo-buildpacks/libpak/v2/bard"
 	"github.com/paketo-buildpacks/libpak/v2/effect"
 	"github.com/paketo-buildpacks/libpak/v2/effect/mocks"
+	"github.com/paketo-buildpacks/libpak/v2/log"
 	"github.com/paketo-buildpacks/libpak/v2/sbom"
 	"github.com/sclevine/spec"
 	"github.com/stretchr/testify/mock"
@@ -62,7 +62,7 @@ func testSBOM(t *testing.T, context spec.G, it spec.S) {
 			}).Return(nil)
 
 			// uses interface here intentionally, to force that inteface and implementation match
-			scanner = sbom.NewSyftCLISBOMScanner(layers, &executor, bard.NewLogger(io.Discard))
+			scanner = sbom.NewSyftCLISBOMScanner(layers, &executor, log.NewLogger(io.Discard))
 
 			Expect(scanner.ScanBuild("something", format)).To(Succeed())
 
@@ -105,7 +105,7 @@ func testSBOM(t *testing.T, context spec.G, it spec.S) {
 			}).Return(nil)
 
 			// uses interface here intentionally, to force that inteface and implementation match
-			scanner = sbom.NewSyftCLISBOMScanner(layers, &executor, bard.NewLogger(io.Discard))
+			scanner = sbom.NewSyftCLISBOMScanner(layers, &executor, log.NewLogger(io.Discard))
 
 			Expect(scanner.ScanBuild("something", format)).To(Succeed())
 
@@ -133,7 +133,7 @@ func testSBOM(t *testing.T, context spec.G, it spec.S) {
 			scanner := sbom.SyftCLISBOMScanner{
 				Executor: &executor,
 				Layers:   layers,
-				Logger:   bard.NewLogger(io.Discard),
+				Logger:   log.NewLogger(io.Discard),
 			}
 
 			Expect(scanner.ScanLayer(layer, "something", format)).To(Succeed())
@@ -160,7 +160,7 @@ func testSBOM(t *testing.T, context spec.G, it spec.S) {
 			scanner := sbom.SyftCLISBOMScanner{
 				Executor: &executor,
 				Layers:   layers,
-				Logger:   bard.NewLogger(io.Discard),
+				Logger:   log.NewLogger(io.Discard),
 			}
 
 			Expect(scanner.ScanLaunch("something", libcnb.CycloneDXJSON, libcnb.SyftJSON, libcnb.SPDXJSON)).To(Succeed())


### PR DESCRIPTION
## Summary

This PR has a number of fixes to the libpak API that are breaking changes. These should be evolving the API forward and cleaning up common sources of issues and confusion in the previous version.

## Use Cases

Code clean up & easier API to use.

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
