### PR TITLE
Revert "adds logic to remove http query params from destination file name"

### DIFF
--- a/dependency_cache.go
+++ b/dependency_cache.go
@@ -167,9 +167,7 @@ func (d *DependencyCache) Artifact(dependency BuildpackDependency, mods ...Reque
 		actual   BuildpackDependency
 		artifact string
 		file     string
-		hasher   = sha256.New()
 		uri      = dependency.URI
-		uriSha   string
 	)
 
 	for d, u := range d.Mappings {
@@ -179,18 +177,12 @@ func (d *DependencyCache) Artifact(dependency BuildpackDependency, mods ...Reque
 		}
 	}
 
-	// downloaded artifact will have the uri sha as its filename
-	hasher.Write([]byte(uri))
-	uriSha = hex.EncodeToString(hasher.Sum(nil))
-
 	if dependency.SHA256 == "" {
 		d.Logger.Headerf("%s Dependency has no SHA256. Skipping cache.",
 			color.New(color.FgYellow, color.Bold).Sprint("Warning:"))
 
 		d.Logger.Bodyf("%s from %s", color.YellowString("Downloading"), uri)
-
-		artifact = filepath.Join(d.DownloadPath, uriSha)
-
+		artifact = filepath.Join(d.DownloadPath, filepath.Base(uri))
 		if err := d.download(uri, artifact, mods...); err != nil {
 			return nil, fmt.Errorf("unable to download %s\n%w", uri, err)
 		}
@@ -227,7 +219,7 @@ func (d *DependencyCache) Artifact(dependency BuildpackDependency, mods ...Reque
 	}
 
 	d.Logger.Bodyf("%s from %s", color.YellowString("Downloading"), uri)
-	artifact = filepath.Join(d.DownloadPath, dependency.SHA256, uriSha)
+	artifact = filepath.Join(d.DownloadPath, dependency.SHA256, filepath.Base(uri))
 	if err := d.download(uri, artifact, mods...); err != nil {
 		return nil, fmt.Errorf("unable to download %s\n%w", uri, err)
 	}


### PR DESCRIPTION
Reverts paketo-buildpacks/libpak#273

A bug was discovered as a result of this change, wrt caching & offline buildpacks - when restoring dependencies from the cache, the dependency URI is used and not the URI SHA.

Given the potential to break apps on rebuild, this PR proposes reverting the change - it could be implemented for v2 of Libpak via #287

We will cut a new libpak and release new component buildpacks based on this - the composites have not yet been released with #273.