### PR TITLE
Add support for ARM64 support in DependencyResolver

### DIFF
--- a/buildpack.go
+++ b/buildpack.go
@@ -560,7 +560,7 @@ func archFromPURL(rawPURL string) (string, error) {
 		return arch[0], nil
 	}
 
-	return "amd64", nil
+	return archFromSystem(), nil
 }
 
 func archFromSystem() string {

--- a/buildpack_test.go
+++ b/buildpack_test.go
@@ -355,6 +355,33 @@ func testBuildpack(t *testing.T, context spec.G, it spec.S) {
 				}))
 			})
 
+			it("filters by arch where arch should match any", func() {
+				resolver.Dependencies = []libpak.BuildpackDependency{
+					{
+						ID:      "test-id-1",
+						Name:    "test-name",
+						Version: "1.0",
+						URI:     "test-uri",
+						SHA256:  "test-sha256",
+						Stacks:  []string{"test-stack-1", "test-stack-2"},
+						PURL:    "pkg:generic/spring-cloud-bindings@1.2.3",
+					},
+				}
+				resolver.StackID = "test-stack-1"
+
+				t.Setenv("BP_ARCH", "arm64")
+
+				Expect(resolver.Resolve("test-id-1", "1.0")).To(Equal(libpak.BuildpackDependency{
+					ID:      "test-id-1",
+					Name:    "test-name",
+					Version: "1.0",
+					URI:     "test-uri",
+					SHA256:  "test-sha256",
+					Stacks:  []string{"test-stack-1", "test-stack-2"},
+					PURL:    "pkg:generic/spring-cloud-bindings@1.2.3",
+				}))
+			})
+
 			it("filters by version constraint", func() {
 				resolver.Dependencies = []libpak.BuildpackDependency{
 					{

--- a/buildpack_test.go
+++ b/buildpack_test.go
@@ -282,6 +282,10 @@ func testBuildpack(t *testing.T, context spec.G, it spec.S) {
 			resolver libpak.DependencyResolver
 		)
 
+		it.Before(func() {
+			t.Setenv("BP_ARCH", "amd64") // force for test consistency
+		})
+
 		context("Resolve", func() {
 
 			it("filters by id", func() {
@@ -312,6 +316,42 @@ func testBuildpack(t *testing.T, context spec.G, it spec.S) {
 					URI:     "test-uri",
 					SHA256:  "test-sha256",
 					Stacks:  []string{"test-stack-1", "test-stack-2"},
+				}))
+			})
+
+			it("filters by arch", func() {
+				resolver.Dependencies = []libpak.BuildpackDependency{
+					{
+						ID:      "test-id-1",
+						Name:    "test-name",
+						Version: "1.0",
+						URI:     "test-uri-amd64",
+						SHA256:  "test-sha256",
+						Stacks:  []string{"test-stack-1", "test-stack-2"},
+						PURL:    "pkg:generic/bellsoft-jdk@8.0.382?arch=amd64",
+					},
+					{
+						ID:      "test-id-1",
+						Name:    "test-name",
+						Version: "1.0",
+						URI:     "test-uri-arm64",
+						SHA256:  "test-sha256",
+						Stacks:  []string{"test-stack-1", "test-stack-2"},
+						PURL:    "pkg:generic/bellsoft-jdk@8.0.382?arch=arm64",
+					},
+				}
+				resolver.StackID = "test-stack-1"
+
+				t.Setenv("BP_ARCH", "arm64")
+
+				Expect(resolver.Resolve("test-id-1", "1.0")).To(Equal(libpak.BuildpackDependency{
+					ID:      "test-id-1",
+					Name:    "test-name",
+					Version: "1.0",
+					URI:     "test-uri-arm64",
+					SHA256:  "test-sha256",
+					Stacks:  []string{"test-stack-1", "test-stack-2"},
+					PURL:    "pkg:generic/bellsoft-jdk@8.0.382?arch=arm64",
 				}))
 			})
 

--- a/carton/package.go
+++ b/carton/package.go
@@ -89,7 +89,7 @@ func (p Package) Create(options ...Option) {
 		config.exitHandler.Error(fmt.Errorf("unable to decode buildpack %s\n%w", file, err))
 		return
 	}
-	logger.Debug("Buildpack: %+v", buildpack)
+	logger.Debugf("Buildpack: %+v", buildpack)
 
 	metadata, err := libpak.NewBuildpackMetadata(buildpack.Metadata)
 	if err != nil {
@@ -102,7 +102,7 @@ func (p Package) Create(options ...Option) {
 	for _, i := range metadata.IncludeFiles {
 		entries[i] = filepath.Join(p.Source, i)
 	}
-	logger.Debug("Include files: %+v", entries)
+	logger.Debugf("Include files: %+v", entries)
 
 	if p.Version != "" {
 		buildpack.Info.Version = p.Version


### PR DESCRIPTION
## Summary

This commit adds support to DependencyResolver.Resolve to pick a Dependency and consider the architecture. It looks at either `BP_ARCH` (if set) or `runtime.GOARCH` otherwise. It then compares this to the `arch=` value that is set in PURL. We are using the PURL because it exists already and already contains the arch info. This is opposed to adding a new property to the dependency metadata. We *may* end up doing that still, but this just gets things working more quickly now and we can change this in the future.

This should be backward compatible. When resolving a dependency, it will read the PURL and pull out the arch.

- If the PURL is not set, it defaults to AMD64 which is the present behavior
- If the PURL is set but does not have an `arch=`, it defaults to AMD64 which is the present behavior
- If the PURL is malformed, it will error. That will be a difference in behavior, but should not happen unless something is wrong with the metadata.
- If the PURL is set and has an arch, then it'll return that value.

It then compares this to the "present" value as described above. If the two match, the dependency is kept as a candidate.

### Risks

1. If someone set a PURL for a dep and set an arch, but set it to some incorrect value like `foo`. It would then use `foo` and never match. Previously, that arch would have been ignored and things would have work. I assert that this is a problem with the buildpack metadata, much like an invalid PURL. It should be patched and fixed in the buildpack.

2. ~It's not clear how to handle the situation where there is no ARCH. Like a JAR file. In that case, nothing returned from the dep's PURL arch will ever match the present arch, so that dep won't install properly. I suspect the simplest solution would be to make a special key like `all` that matches all and use that. It would require a few changes to buildpack dep metadata though.~

## Use Cases

Required for ARM64 support.

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
