### PR TITLE
Add support for architecture selection during updating of buildpack dependencies

### DIFF
--- a/carton/buildpack_dependency.go
+++ b/carton/buildpack_dependency.go
@@ -157,7 +157,14 @@ func (b BuildpackDependency) Update(options ...Option) {
 			}
 		}
 
+		// if not set, we presently need to default to amd64 because a lot of deps do not specify arch
+		//   in the future when we add the arch field to our deps, then we can remove this because empty should then mean noarch
+		if depArch == "" {
+			depArch = "amd64"
+		}
+
 		if depId == b.ID && depArch == b.Arch {
+
 			depVersionUnwrapped, found := dep["version"]
 			if !found {
 				continue

--- a/carton/buildpack_dependency_test.go
+++ b/carton/buildpack_dependency_test.go
@@ -74,6 +74,7 @@ source-sha256 = "test-source-sha256-1"
 		d := carton.BuildpackDependency{
 			BuildpackPath:  path,
 			ID:             "test-id",
+			Arch:           "amd64",
 			SHA256:         "test-sha256-2",
 			URI:            "test-uri-2",
 			Version:        "test-version-2",
@@ -123,6 +124,7 @@ cpes    = ["cpe:2.3:a:test-vendor:test-product:test-version-1:patch1:*:*:*:*:*:*
 		d := carton.BuildpackDependency{
 			BuildpackPath:  path,
 			ID:             "test-id",
+			Arch:           "amd64",
 			SHA256:         "test-sha256-2",
 			URI:            "test-uri-2",
 			Version:        "test-version-2",
@@ -174,6 +176,7 @@ cpes    = ["cpe:2.3:a:test-vendor:test-product:test-version-1:patch1:*:*:*:*:*:*
 		d := carton.BuildpackDependency{
 			BuildpackPath:  path,
 			ID:             "test-id",
+			Arch:           "amd64",
 			SHA256:         "test-sha256-2",
 			URI:            "test-uri-2",
 			Version:        "test-version-2",
@@ -182,8 +185,8 @@ cpes    = ["cpe:2.3:a:test-vendor:test-product:test-version-1:patch1:*:*:*:*:*:*
 			PURLPattern:    `different-version-[\d]`,
 			CPE:            "test-version-2:patch2",
 			CPEPattern:     `test-version-[\d]:patch[\d]`,
-			Source:          "test-new-source",
-			SourceSHA256:    "test-new-source-sha",
+			Source:         "test-new-source",
+			SourceSHA256:   "test-new-source-sha",
 		}
 
 		d.Update(carton.WithExitHandler(exitHandler))
@@ -243,6 +246,7 @@ source-sha256 = "test-source-sha256-2"
 		d := carton.BuildpackDependency{
 			BuildpackPath:  path,
 			ID:             "test-id",
+			Arch:           "amd64",
 			SHA256:         "test-sha256-3",
 			URI:            "test-uri-3",
 			Version:        "test-version-3",
@@ -309,6 +313,7 @@ cpes    = ["cpe:2.3:a:test-vendor:test-product:test-version-1:patch1:*:*:*:*:*:*
 		d := carton.BuildpackDependency{
 			BuildpackPath:  path,
 			ID:             "test-id",
+			Arch:           "amd64",
 			SHA256:         "test-sha256-2",
 			URI:            "test-uri-2",
 			Version:        "test-version-2",
@@ -359,6 +364,7 @@ cpes    = ["cpe:2.3:a:test-vendor:test-product:test-version-1:patch1:*:*:*:*:*:*
 		d := carton.BuildpackDependency{
 			BuildpackPath:  path,
 			ID:             "test-id",
+			Arch:           "amd64",
 			SHA256:         "test-sha256-2",
 			URI:            "test-uri-2",
 			Version:        "test-version-2",
@@ -410,6 +416,7 @@ cpes    = 1234
 		d := carton.BuildpackDependency{
 			BuildpackPath:  path,
 			ID:             "test-id",
+			Arch:           "amd64",
 			SHA256:         "test-sha256-2",
 			URI:            "test-uri-2",
 			Version:        "test-version-2",
@@ -463,6 +470,7 @@ version = "1.2.3"
 		d := carton.BuildpackDependency{
 			BuildpackPath:  path,
 			ID:             "test-id",
+			Arch:           "amd64",
 			SHA256:         "test-sha256-2",
 			URI:            "test-uri-2",
 			Version:        "test-version-2",

--- a/cmd/update-buildpack-dependency/main.go
+++ b/cmd/update-buildpack-dependency/main.go
@@ -32,6 +32,7 @@ func main() {
 	flagSet := pflag.NewFlagSet("Update Buildpack Dependency", pflag.ExitOnError)
 	flagSet.StringVar(&b.BuildpackPath, "buildpack-toml", "", "path to buildpack.toml")
 	flagSet.StringVar(&b.ID, "id", "", "the id of the dependency")
+	flagSet.StringVar(&b.Arch, "arch", "", "the arch of the dependency")
 	flagSet.StringVar(&b.SHA256, "sha256", "", "the new sha256 of the dependency")
 	flagSet.StringVar(&b.URI, "uri", "", "the new uri of the dependency")
 	flagSet.StringVar(&b.Version, "version", "", "the new version of the dependency")
@@ -53,6 +54,10 @@ func main() {
 
 	if b.ID == "" {
 		log.Fatal("id must be set")
+	}
+
+	if b.Arch == "" {
+		b.Arch = "amd64"
 	}
 
 	if b.SHA256 == "" {


### PR DESCRIPTION
## Summary

The `update-buildpack-dependency` too doesn't match correctly with the introduction of dependency architectures. This includes architecture as a consideration when filtering the dependencies to pick what is updated. A dependency now needs to match both the ID and ARCH.

This is presently pulling the architecture from the PURL as it's the only currently reliable spot to get it. In the future, when all of the buildpacks have switched to it, we should pull from the arch field.

## Use Cases

Multi-arch support.

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
