### PR TITLE
Obfuscate Credentials in Logs

### DIFF
--- a/carton/package.go
+++ b/carton/package.go
@@ -185,7 +185,8 @@ func (p Package) Create(options ...Option) {
 
 			f, err := cache.Artifact(dep, n.BasicAuth)
 			if err != nil {
-				config.exitHandler.Error(fmt.Errorf("unable to download %s\n%w", dep.URI, err))
+				logger.Debugf("fetching dependency %s failed\n%w", dep.Name, err)
+				config.exitHandler.Error(fmt.Errorf("unable to download %s. see DEBUG log level", dep.Name))
 				return
 			}
 			if err = f.Close(); err != nil {

--- a/dependency_cache.go
+++ b/dependency_cache.go
@@ -189,7 +189,7 @@ func (d *DependencyCache) Artifact(dependency BuildpackDependency, mods ...Reque
 			color.New(color.FgYellow, color.Bold).Sprint("Warning:"))
 
 		d.Logger.Bodyf("%s from %s", color.YellowString("Downloading"), urlP.Redacted())
-		artifact = filepath.Join(d.DownloadPath, filepath.Base(urlP.Path))
+		artifact = filepath.Join(d.DownloadPath, filepath.Base(uri))
 		if err := d.download(urlP, artifact, mods...); err != nil {
 			return nil, fmt.Errorf("unable to download %s\n%w", urlP.Redacted(), err)
 		}
@@ -226,7 +226,7 @@ func (d *DependencyCache) Artifact(dependency BuildpackDependency, mods ...Reque
 	}
 
 	d.Logger.Bodyf("%s from %s", color.YellowString("Downloading"), urlP.Redacted())
-	artifact = filepath.Join(d.DownloadPath, dependency.SHA256, filepath.Base(urlP.Path))
+	artifact = filepath.Join(d.DownloadPath, dependency.SHA256, filepath.Base(uri))
 	if err := d.download(urlP, artifact, mods...); err != nil {
 		return nil, fmt.Errorf("unable to download %s\n%w", urlP.Redacted(), err)
 	}

--- a/dependency_cache_test.go
+++ b/dependency_cache_test.go
@@ -17,9 +17,11 @@
 package libpak_test
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"testing"
@@ -32,6 +34,7 @@ import (
 	"github.com/sclevine/spec"
 
 	"github.com/paketo-buildpacks/libpak"
+	"github.com/paketo-buildpacks/libpak/bard"
 )
 
 func testDependencyCache(t *testing.T, context spec.G, it spec.S) {
@@ -343,6 +346,26 @@ func testDependencyCache(t *testing.T, context spec.G, it spec.S) {
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(io.ReadAll(a)).To(Equal([]byte("test-fixture")))
+		})
+
+		it("hide uri credentials from log", func() {
+			server.AppendHandlers(ghttp.CombineHandlers(
+				ghttp.RespondWith(http.StatusOK, "test-fixture"),
+			))
+
+			url, err := url.Parse(dependency.URI)
+			Expect(err).NotTo(HaveOccurred())
+			credentials := "basic-username:basic-password"
+			urlWithBasicCreds := url.Scheme + "://" + credentials + "@" + url.Hostname() + ":" + url.Port() + url.Path
+			dependency.URI = urlWithBasicCreds
+
+			var logBuffer bytes.Buffer
+			captureLogger := bard.NewLogger(&logBuffer)
+			dependencyCache.Logger = captureLogger
+			a, err := dependencyCache.Artifact(dependency)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(a).NotTo(BeNil())
+			Expect(logBuffer.String()).NotTo(ContainSubstring(credentials))
 		})
 	})
 }

--- a/layer.go
+++ b/layer.go
@@ -291,7 +291,8 @@ func (d *DependencyLayerContributor) Contribute(layer libcnb.Layer, f Dependency
 	return lc.Contribute(layer, func() (libcnb.Layer, error) {
 		artifact, err := d.DependencyCache.Artifact(d.Dependency, d.RequestModifierFuncs...)
 		if err != nil {
-			return libcnb.Layer{}, fmt.Errorf("unable to get dependency %s\n%w", d.Dependency.ID, err)
+			d.Logger.Debugf("fetching dependency %s failed\n%w", d.Dependency.Name, err)
+			return libcnb.Layer{}, fmt.Errorf("unable to get dependency %s. see DEBUG log level", d.Dependency.Name)
 		}
 		defer artifact.Close()
 


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
When using HTTP basic authentication credentials in binding URIs, this change obfuscates the username and password in the log entries.

## Use Cases
<!-- An explanation of the use cases your change enables -->
When adding a binding for an artifact hosted in a private registry, it can be necessary to provide HTTP basic authentication credentials with the URI. This already works fine for downloading the desired dependency. However, when doing so, the username and password that are part of the URI, get printed to stdout in plain text at the moment. This PR should solve this issue by obfuscating the credentials.
To make sure this change has no adverse side effects in case the provided URI is not well-formed, this implementation uses a regular expression instead of trying to parse the string to a "net/url" object.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
