### PR TITLE
Adds `--target-arch` flag

### DIFF
--- a/carton/package.go
+++ b/carton/package.go
@@ -35,6 +35,8 @@ import (
 	"github.com/paketo-buildpacks/libpak/internal"
 )
 
+const DefaultTargetArch = "all"
+
 // Package is an object that contains the configuration for building a package.
 type Package struct {
 
@@ -58,6 +60,9 @@ type Package struct {
 
 	// Version is a version to substitute into an existing buildpack.toml.
 	Version string
+
+	// TargetArch is the target architecture to package. Default is "all".
+	TargetArch string
 }
 
 // Create creates a package.
@@ -113,7 +118,8 @@ func (p Package) Create(options ...Option) {
 		}
 	}
 
-	if len(supportedTargets) == 0 {
+	oldOutputFormat := len(supportedTargets) == 0
+	if oldOutputFormat {
 		logger.Info("No supported targets found, defaulting to old format")
 	}
 
@@ -122,7 +128,7 @@ func (p Package) Create(options ...Option) {
 	entries := map[string]string{}
 
 	for _, i := range metadata.IncludeFiles {
-		if len(supportedTargets) == 0 || strings.HasPrefix(i, "linux/") || i == "buildpack.toml" {
+		if oldOutputFormat || strings.HasPrefix(i, "linux/") || i == "buildpack.toml" {
 			entries[i] = filepath.Join(p.Source, i)
 		} else {
 			for _, target := range supportedTargets {
@@ -233,8 +239,18 @@ func (p Package) Create(options ...Option) {
 	}
 	sort.Strings(files)
 	for _, d := range files {
-		logger.Bodyf("Adding %s", d)
-		file = filepath.Join(p.Destination, d)
+		if p.TargetArch != DefaultTargetArch && !oldOutputFormat && strings.HasPrefix(d, "linux/") && !strings.HasPrefix(d, fmt.Sprintf("linux/%s", p.TargetArch)) {
+			logger.Debugf("Skipping %s because target arch is %s", d, p.TargetArch)
+			continue
+		}
+
+		targetLocation := d
+		if p.TargetArch != DefaultTargetArch {
+			targetLocation = strings.Replace(d, fmt.Sprintf("linux/%s/", p.TargetArch), "", 1)
+		}
+
+		logger.Bodyf("Adding %s", targetLocation)
+		file = filepath.Join(p.Destination, targetLocation)
 		if err = config.entryWriter.Write(entries[d], file); err != nil {
 			config.exitHandler.Error(fmt.Errorf("unable to write file %s to %s\n%w", entries[d], file, err))
 			return

--- a/cmd/create-package/main.go
+++ b/cmd/create-package/main.go
@@ -37,6 +37,7 @@ func main() {
 	flagSet.BoolVar(&p.StrictDependencyFilters, "strict-filters", false, "require filter to match all data or just some data (default: false)")
 	flagSet.StringVar(&p.Source, "source", defaultSource(), "path to build package source directory (default: $PWD)")
 	flagSet.StringVar(&p.Version, "version", "", "version to substitute into buildpack.toml")
+	flagSet.StringVar(&p.TargetArch, "target-arch", carton.DefaultTargetArch, "target architecture for the package (default: all)")
 
 	if err := flagSet.Parse(os.Args[1:]); err != nil {
 		log.Fatal(fmt.Errorf("unable to parse flags\n%w", err))


### PR DESCRIPTION
## Summary

Adds a `--target-arch` flag which causes the tool to only create a build pack for the target architecture. By default, it builds all architectures. It still supports the old format of buildpack which does not include arch information in the include-files field.

## Use Cases

Resolves #330 

I'm moving:

> In addition, filter the metadata dependencies and only include those for the specified arch.

into #326 because it'll be easier to add there, cause it's not doing dependencies for multi-arch yet.

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
