### PR TITLE
Change `syft packages` to `syft scan`

### DIFF
--- a/sbom/sbom.go
+++ b/sbom/sbom.go
@@ -138,7 +138,7 @@ func (b SyftCLISBOMScanner) ScanLaunch(scanDir string, formats ...libcnb.SBOMFor
 }
 
 func (b SyftCLISBOMScanner) scan(sbomPathCreator func(libcnb.SBOMFormat) string, scanDir string, formats ...libcnb.SBOMFormat) error {
-	args := []string{"packages", "-q"}
+	args := []string{"scan", "-q"}
 
 	for _, format := range formats {
 		args = append(args, "-o", fmt.Sprintf("%s=%s", SBOMFormatToSyftOutputFormat(format), sbomPathCreator(format)))


### PR DESCRIPTION
## Summary
The `syft packages` command was deprecated. This has been generating warning messages in builds for a while now. The new command is `syft scan` and it has the same arguments, so no argument changes are necessary.

## Use Cases

Resolve #350 for v2.

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
