### PR TITLE
Improve error when symlink cannot be accessed during walk

### DIFF
--- a/sherpa/file_listing.go
+++ b/sherpa/file_listing.go
@@ -71,7 +71,7 @@ func NewFileListing(roots ...string) ([]FileEntry, error) {
 			if os.IsNotExist(err) {
 				continue
 			} else if err != nil {
-				results <- result{err: fmt.Errorf("unable to resolve %s\n%w", root, err)}
+				results <- result{err: fmt.Errorf("symlink path %s does not exist according to the OS\n%w", root, err)}
 				return
 			}
 
@@ -178,7 +178,7 @@ func isSymlinkToDir(symlink string, f os.FileInfo) (bool, error) {
 
 		stat, err := os.Stat(path)
 		if err != nil {
-			return false, fmt.Errorf("unable to stat file %s\n%w", path, err)
+			return false, fmt.Errorf("unable to stat file - source path contains a symlink that cannot be followed, at %s\n%w", path, err)
 		}
 
 		return stat.IsDir(), nil


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
The file walk used by libbs e.g. to create a listing of the source/workspace directory can fail if it encounters a directory symlink that it cannot follow - this PR improves the error relating to this situation

## Use Cases
User source path contains a symlink dir/file that cannot be followed

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
