### PR TITLE
Adds method ResolveBoolWithDefault

### DIFF
--- a/sherpa/env_var.go
+++ b/sherpa/env_var.go
@@ -69,8 +69,7 @@ func ResolveBoolErr(name string) (bool, error) {
 		return false, nil
 	}
 
-	t := strings.TrimSpace(s)
-	p, err := strconv.ParseBool(t)
+	p, err := strconv.ParseBool(strings.TrimSpace(s))
 	if err != nil {
 		return false, fmt.Errorf(
 			"invalid value '%s' for key '%s': expected one of [1, t, T, TRUE, true, True, 0, f, F, FALSE, false, False]",
@@ -80,4 +79,19 @@ func ResolveBoolErr(name string) (bool, error) {
 	}
 
 	return p, nil
+}
+
+// ResolveBoolWithDefault resolves a boolean value for a configuration option or returns the default value
+func ResolveBoolWithDefault(name string, defaultVal bool) bool {
+	s, ok := os.LookupEnv(name)
+	if !ok {
+		return defaultVal
+	}
+
+	p, err := strconv.ParseBool(strings.TrimSpace(s))
+	if err != nil {
+		return false
+	}
+
+	return p
 }

--- a/sherpa/env_var_test.go
+++ b/sherpa/env_var_test.go
@@ -172,4 +172,56 @@ func testEnvVar(t *testing.T, context spec.G, it spec.S) {
 			})
 		})
 	})
+
+	context("ResolveBoolWithDefault", func() {
+		context("variable not set", func() {
+			it("returns default if not set", func() {
+				boolean := sherpa.ResolveBoolWithDefault("TEST_KEY", true)
+				Expect(boolean).To(BeTrue())
+			})
+		})
+
+		context("variable is set to true value", func() {
+			it.After(func() {
+				Expect(os.Unsetenv("TEST_KEY")).To(Succeed())
+			})
+
+			it("returns true", func() {
+				for _, form := range []string{"1", "t", "T", "TRUE", "true", "True", "\t1\n"} {
+					Expect(os.Setenv("TEST_KEY", form))
+					boolean := sherpa.ResolveBoolWithDefault("TEST_KEY", false)
+					Expect(boolean).To(BeTrue())
+					Expect(os.Unsetenv("TEST_KEY")).To(Succeed())
+				}
+			})
+		})
+
+		context("variable is set to non-true value", func() {
+			it.After(func() {
+				Expect(os.Unsetenv("TEST_KEY")).To(Succeed())
+			})
+
+			it("returns false", func() {
+				for _, form := range []string{"0", "f", "F", "FALSE", "false", "False", "\tF\n"} {
+					Expect(os.Setenv("TEST_KEY", form))
+					boolean := sherpa.ResolveBoolWithDefault("TEST_KEY", true)
+					Expect(boolean).To(BeFalse())
+					Expect(os.Unsetenv("TEST_KEY")).To(Succeed())
+				}
+			})
+		})
+
+		context("variable is set to an invalid value", func() {
+			it.After(func() {
+				Expect(os.Unsetenv("TEST_KEY")).To(Succeed())
+			})
+
+			it("returns false", func() {
+				Expect(os.Setenv("TEST_KEY", "foo"))
+				boolean := sherpa.ResolveBoolWithDefault("TEST_KEY", true)
+				Expect(boolean).To(BeTrue())
+				Expect(os.Unsetenv("TEST_KEY")).To(Succeed())
+			})
+		})
+	})
 }


### PR DESCRIPTION
## Summary

This allows you to fetch a boolean configuration and change the default, like if you want the default to be true. Not used often, but it is helpful for a couple of buildpacks.

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
