### PR TITLE
Only enforce strict arch checking when dependency specifies arch

### DIFF
--- a/buildmodule.go
+++ b/buildmodule.go
@@ -302,7 +302,7 @@ func (d *DependencyResolver) Resolve(id string, version string) (BuildModuleDepe
 		if err != nil {
 			return BuildModuleDependency{}, fmt.Errorf("unable to compare arch\n%w", err)
 		}
-		if arch != archFromSystem() {
+		if c.Arch != "" && arch != archFromSystem() {
 			continue
 		}
 

--- a/buildmodule_test.go
+++ b/buildmodule_test.go
@@ -283,10 +283,6 @@ func testBuildpack(t *testing.T, context spec.G, it spec.S) {
 			resolver libpak.DependencyResolver
 		)
 
-		it.Before(func() {
-			t.Setenv("BP_ARCH", "amd64") // force for test consistency
-		})
-
 		context("Resolve", func() {
 			it("filters by id", func() {
 				resolver.Dependencies = []libpak.BuildModuleDependency{
@@ -325,15 +321,6 @@ func testBuildpack(t *testing.T, context spec.G, it spec.S) {
 						ID:       "test-id-1",
 						Name:     "test-name",
 						Version:  "1.0",
-						URI:      "test-uri-amd64",
-						Checksum: "sha256:test-sha256",
-						Stacks:   []string{"test-stack-1", "test-stack-2"},
-						PURLS:    []string{"pkg:generic/bellsoft-jdk@8.0.382?arch=amd64"},
-					},
-					{
-						ID:       "test-id-1",
-						Name:     "test-name",
-						Version:  "1.0",
 						URI:      "test-uri-arm64",
 						Checksum: "sha256:test-sha256",
 						Stacks:   []string{"test-stack-1", "test-stack-2"},
@@ -357,7 +344,7 @@ func testBuildpack(t *testing.T, context spec.G, it spec.S) {
 				}))
 			})
 
-			it("filters by arch where arch should match any", func() {
+			it("should match any when arch is not set", func() {
 				resolver.Dependencies = []libpak.BuildModuleDependency{
 					{
 						ID:       "test-id-1",
@@ -370,8 +357,6 @@ func testBuildpack(t *testing.T, context spec.G, it spec.S) {
 					},
 				}
 				resolver.StackID = "test-stack-1"
-
-				t.Setenv("BP_ARCH", "arm64")
 
 				Expect(resolver.Resolve("test-id-1", "1.0")).To(Equal(libpak.BuildModuleDependency{
 					ID:       "test-id-1",


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary

This PR does the following:
* Disables strict dependency checking based on architecture
* Only set BP_ARCH for unit tests related to dependencies with architecture

this relates to https://github.com/paketo-buildpacks/packit/pull/671 and will ensure consistency between packit and libpak

## Use Cases
<!-- An explanation of the use cases your change enables -->

The [0059-standard-dependency-metadata-format](https://github.com/paketo-buildpacks/rfcs/blob/e601a1b0bbf21b54da05588df876fb1d989e2497/text/0059-standard-dependency-metadata-format.md?plain=1#L54-L56) RFC says that when `os` and `arch` are not given it should be assumed that the dependency is compatible with any architecture. This will be a requirement for some buildpacks such as [pip](https://github.com/paketo-buildpacks/pip/blob/58c86600835adab848d144c155c8e1f7002c4dbf/buildpack.toml#L25) and [yarn](https://github.com/paketo-buildpacks/yarn/blob/8b4b8e00f2168f22d4e7b0ddc29e7510f59d5a04/buildpack.toml#L29), which work on any architecture.

This PR makes it so that when dependencies specify `arch` they can only be used on systems with the specified `arch` or if env `BP_ARCH` is set to match. This means strict checking is only enabled when dependencies specify `arch`.


## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
