### PR TITLE
Add binding predicate OfKeyWithValueFromSecret

### DIFF
--- a/bindings/resolve.go
+++ b/bindings/resolve.go
@@ -34,6 +34,19 @@ func OfType(t string) Predicate {
 	}
 }
 
+// OfKeyWithValueFromSecret returns a Predicate that returns true if a given binding has Key that matches k with Value that matches v.
+// The comparison is case-insensitive.
+func OfKeyWithValueFromSecret(k string, v string) Predicate {
+	return func(bind libcnb.Binding) bool {
+		value, exists := bind.Secret[k]
+		if !exists {
+			return false
+		}
+
+		return strings.EqualFold(value, v)
+	}
+}
+
 // OfProvider returns a Predicate that returns true if a given binding has Provider that matches p. The comparison is
 // case-insensitive.
 func OfProvider(p string) Predicate {

--- a/bindings/resolve_test.go
+++ b/bindings/resolve_test.go
@@ -86,6 +86,79 @@ func testResolve(t *testing.T, context spec.G, it spec.S) {
 			})
 		})
 
+		context("ByKeyWithValueFromSecret", func() {
+			it("returns all with matching type", func() {
+				b := []libcnb.Binding{
+					{
+						Name:     "name1",
+						Type:     "some-type",
+						Provider: "some-provider",
+						Secret: map[string]string{
+							"type": "other-type",
+							"user": "some-user",
+							"pass": "some-pass",
+						},
+					},
+					{
+						Name:     "name2",
+						Type:     "some-type",
+						Provider: "other-provider",
+						Secret: map[string]string{
+							"type": "other-type",
+							"user": "some-user",
+							"pass": "some-pass",
+						},
+					},
+					{
+						Name:     "name3",
+						Type:     "other-type",
+						Provider: "some-provider",
+						Secret: map[string]string{
+							"type": "foo",
+							"user": "some-user",
+							"pass": "some-pass",
+						},
+					},
+					{
+						Name:     "name1",
+						Type:     "unknown",
+						Provider: "unknown",
+						Secret: map[string]string{
+							"type": "some-type",
+							"user": "some-user",
+							"pass": "some-pass",
+						},
+					},
+				}
+
+				resolved := bindings.Resolve(b,
+					bindings.OfKeyWithValueFromSecret("type", "other-type"),
+				)
+				Expect(resolved).To(Equal(libcnb.Bindings{
+					{
+						Name:     "name1",
+						Type:     "some-type",
+						Provider: "some-provider",
+						Secret: map[string]string{
+							"type": "other-type",
+							"user": "some-user",
+							"pass": "some-pass",
+						},
+					},
+					{
+						Name:     "name2",
+						Type:     "some-type",
+						Provider: "other-provider",
+						Secret: map[string]string{
+							"type": "other-type",
+							"user": "some-user",
+							"pass": "some-pass",
+						},
+					},
+				}))
+			})
+		})
+
 		context("ByProvider", func() {
 			it("returns all with matching type", func() {
 				resolved := bindings.Resolve(binds,


### PR DESCRIPTION
## Summary
- This predicate allows finding a binding where there is a field in the secret with a particular value

## Use Cases
This change was implemented on main in #428. Backporting to 1.x because we still use that version internally. 

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ x I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
