### PR TITLE
Fix comparison of layer metadata

### DIFF
--- a/layer.go
+++ b/layer.go
@@ -21,6 +21,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/BurntSushi/toml"
 	"github.com/google/go-cmp/cmp"
@@ -176,10 +177,95 @@ func (l *LayerContributor) checkIfMetadataMatches(layer libcnb.Layer) (map[strin
 		return map[string]interface{}{}, false, fmt.Errorf("unable to decode metadata\n%w", err)
 	}
 
-	l.Logger.Debugf("Expected metadata: %+v", expected)
-	l.Logger.Debugf("Actual metadata: %+v", layer.Metadata)
+	l.Logger.Debugf("Expected metadata: %#v", expected)
+	l.Logger.Debugf("Actual metadata: %#v", layer.Metadata)
 
-	return expected, cmp.Equal(expected, layer.Metadata), nil
+	equal := cmp.Equal(expected, layer.Metadata, timestampMetadataComparer())
+	l.Logger.Debugf("Comparison: %v", equal)
+
+	if !equal {
+		l.Logger.Debugf("Diff:\n%s", cmp.Diff(expected, layer.Metadata, timestampMetadataComparer()))
+	}
+
+	return expected, equal, nil
+}
+
+func timestampMetadataComparer() cmp.Option {
+	return cmp.Options{
+		cmp.FilterValues(func(left, right interface{}) bool {
+			_, leftIsTimestamp := parseMetadataTimestamp(left)
+			_, rightIsTimestamp := parseMetadataTimestamp(right)
+
+			return leftIsTimestamp && rightIsTimestamp
+		}, cmp.Comparer(func(left, right interface{}) bool {
+			leftTime, leftIsTimestamp := parseMetadataTimestamp(left)
+			rightTime, rightIsTimestamp := parseMetadataTimestamp(right)
+
+			if !leftIsTimestamp || !rightIsTimestamp {
+				return false
+			}
+
+			return leftTime.UTC().Equal(rightTime.UTC())
+		})),
+		cmp.FilterValues(func(left, right interface{}) bool {
+			return isNumeric(left) && isNumeric(right)
+		}, cmp.Comparer(func(left, right interface{}) bool {
+			leftVal := toFloat64(left)
+			rightVal := toFloat64(right)
+
+			return leftVal == rightVal
+		})),
+	}
+}
+
+func isNumeric(value interface{}) bool {
+	switch value.(type) {
+	case int, int32, int64, uint, uint32, uint64, float32, float64:
+		return true
+	}
+	return false
+}
+
+func toFloat64(value interface{}) float64 {
+	switch v := value.(type) {
+	case int:
+		return float64(v)
+	case int32:
+		return float64(v)
+	case int64:
+		return float64(v)
+	case uint:
+		return float64(v)
+	case uint32:
+		return float64(v)
+	case uint64:
+		return float64(v)
+	case float32:
+		return float64(v)
+	case float64:
+		return v
+	}
+	return 0
+}
+
+func parseMetadataTimestamp(value interface{}) (time.Time, bool) {
+	switch v := value.(type) {
+	case time.Time:
+		return v, true
+	case string:
+		for _, layout := range []string{
+			time.RFC3339Nano,
+			time.RFC3339,
+			"2006-01-02 15:04:05 -0700 MST",
+		} {
+			parsed, err := time.Parse(layout, v)
+			if err == nil {
+				return parsed, true
+			}
+		}
+	}
+
+	return time.Time{}, false
 }
 
 func (l *LayerContributor) checkIfLayerRestored(layer libcnb.Layer) (bool, error) {
@@ -202,7 +288,7 @@ func (l *LayerContributor) checkIfLayerRestored(layer libcnb.Layer) (bool, error
 		}
 	}
 
-	l.Logger.Debugf("Check If Layer Restored -> tomlExists: %s, layerDirExists: %s, dirContents: %s, cache: %s, build: %s",
+	l.Logger.Debugf("Check If Layer Restored -> tomlExists: %t, layerDirExists: %t, dirContents: %v, cache: %t, build: %t",
 		tomlExists, layerDirExists, dirContents, l.ExpectedTypes.Cache, l.ExpectedTypes.Build)
 
 	// nolint:staticcheck

--- a/layer_test.go
+++ b/layer_test.go
@@ -95,6 +95,128 @@ func testLayer(t *testing.T, context spec.G, it spec.S) {
 			Expect(called).To(BeTrue())
 		})
 
+		it("does not call function when timestamp metadata differs only by representation", func() {
+			zero := time.Time{}.UTC()
+
+			lc.ExpectedMetadata = map[string]interface{}{
+				"dependency": map[string]interface{}{
+					"deprecation_date": zero,
+					"eol-date":         zero,
+				},
+			}
+
+			layer.Metadata = map[string]interface{}{
+				"dependency": map[string]interface{}{
+					"deprecation_date": "0001-01-01T00:00:00Z",
+					"eol-date":         "0001-01-01T00:00:00Z",
+				},
+			}
+
+			var called bool
+
+			err := lc.Contribute(layer, func(_ *libcnb.Layer) error {
+				called = true
+				return nil
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(called).To(BeFalse())
+		})
+
+		it("calls function when timestamp metadata values are actually different", func() {
+			expectedTime, err := time.Parse(time.RFC3339, "2021-04-01T00:00:00Z")
+			Expect(err).NotTo(HaveOccurred())
+
+			lc.ExpectedMetadata = map[string]interface{}{
+				"dependency": map[string]interface{}{
+					"eol-date": expectedTime,
+				},
+			}
+
+			layer.Metadata = map[string]interface{}{
+				"dependency": map[string]interface{}{
+					"eol-date": "2021-05-01T00:00:00Z",
+				},
+			}
+
+			var called bool
+
+			err = lc.Contribute(layer, func(_ *libcnb.Layer) error {
+				called = true
+				return nil
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(called).To(BeTrue())
+		})
+
+		it("does not call function when timestamp metadata differs only by UTC offset representation", func() {
+			expectedTime, err := time.Parse(time.RFC3339, "2021-04-01T00:00:00Z")
+			Expect(err).NotTo(HaveOccurred())
+
+			lc.ExpectedMetadata = map[string]interface{}{
+				"dependency": map[string]interface{}{
+					"eol-date": expectedTime,
+				},
+			}
+
+			layer.Metadata = map[string]interface{}{
+				"dependency": map[string]interface{}{
+					"eol-date": "2021-04-01T00:00:00+00:00",
+				},
+			}
+
+			var called bool
+
+			err = lc.Contribute(layer, func(_ *libcnb.Layer) error {
+				called = true
+				return nil
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(called).To(BeFalse())
+		})
+
+		it("does not call function when numeric metadata differs only by type (int64 vs float64 same value)", func() {
+			lc.ExpectedMetadata = map[string]interface{}{
+				"components": int64(0),
+			}
+
+			layer.Metadata = map[string]interface{}{
+				"components": float64(0),
+			}
+
+			var called bool
+
+			err := lc.Contribute(layer, func(_ *libcnb.Layer) error {
+				called = true
+				return nil
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(called).To(BeFalse())
+		})
+
+		it("calls function when numeric metadata values are actually different", func() {
+			lc.ExpectedMetadata = map[string]interface{}{
+				"components": int64(0),
+			}
+
+			layer.Metadata = map[string]interface{}{
+				"components": float64(1),
+			}
+
+			var called bool
+
+			err := lc.Contribute(layer, func(_ *libcnb.Layer) error {
+				called = true
+				return nil
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(called).To(BeTrue())
+		})
+
 		context("reloads layers not restored", func() {
 			var called bool
 


### PR DESCRIPTION
## Summary
We switched to using `cmp.Equals` to compare the layers, but we have reintroduced two bugs.

1. Where it does not compare dates correctly.
2. Where it does not compare numbers correctly.

Both are caused because we are deserializing TOML data into an interface, sometimes dates are retried as Time type and sometimes a string. Similarly, sometimes it's an int and sometimes a float. This depends on how the TOML is written and deserialized.

This change uses a `cmp.Equals` option method to define a configuration that looks for the time-like strings, parses them to Time objects and then compares them. It does something similar with the numbers, coalescing them all to floats for comparison. That way we end up with consistent time comparisons.

## Use Cases

Example output where the diffs show 

```
[builder] Diff:
[builder]   map[string]any{
[builder]    "cert-file": string("6d84ab71cb726c0641b0af84303c316e3fa50db941dc8507d09045eb2fa5d238"),
[builder]    "dependency": map[string]any{
[builder]    "arch": string(""),
[builder]    "checksum": string(""),
[builder]    "cpes": []any{string("cpe:2.3:a:oracle:jre:21.0.5:::::::")},
[builder] -  "deprecation_date": s"0001-01-01 00:00:00 +0000 UTC",
[builder] +  "deprecation_date": string("0001-01-01T00:00:00Z"),
[builder] -  "eol-date": s"0001-01-01 00:00:00 +0000 UTC",
[builder] +  "eol-date": string("0001-01-01T00:00:00Z"),
[builder]    "id": string("jre-bellsoft-liberica"),
[builder]    "licenses": []map[string]any{{"type": string("GPL-2.0 WITH Classpath-exception-2.0"), "uri": string("[https://openjdk.java.net/legal/gplv2+ce.html")}}](vscode-file://vscode-app/Users/dmikusa/Applications/Visual%20Studio%20Code%20Go/Visual%20Studio%20Code%20Go.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html),
[builder]    ... // 5 identical entries
[builder]    "source-checksum": string(""),
[builder]    "stacks": []any{string("*")},
[builder] -  "strip-components": int64(0),
[builder] +  "strip-components": float64(0),
[builder]    "uri": string("[https://github.com/bell-sw/Liberica/releases/download/21.0.5+11/](vscode-file://vscode-app/Users/dmikusa/Applications/Visual%20Studio%20Code%20Go/Visual%20Studio%20Code%20Go.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)"...),
[builder]    "version": string("21.0.5"),
[builder]    },
[builder]   }
```
